### PR TITLE
Automatically kill http server process

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,6 @@ for software, hosting images and the metadata Uptane requires.
 import demo.demo_oem_repo as do
 do.clean_slate()
 ```
-After the demo, to end hosting:
-```python
-do.kill_server()
-```
 
 
 ### WINDOW 2: the Director
@@ -90,11 +86,6 @@ dd.write_to_live()
 ```
 As a result of the above, the Director will instruct ECU 11111 in vehicle 111 to install file5.txt. Since this file is not on (and validated by) the Image Repository, the Primary will refuse to download it (and a Full Verification Secondary would likewise refuse it even if a compromised Primary delivered it to the Secondary).
 
-After the demo, to end HTTP hosting (but not XMLRPC serving, which requires
-exiting the shell), do this (or else you'll have a zombie Python process to kill)
-```python
-dd.kill_server()
-```
 
 
 ### WINDOW 3: the Timeserver:

--- a/demo/demo_director.py
+++ b/demo/demo_director.py
@@ -59,6 +59,7 @@ from uptane import GREEN, RED, YELLOW, ENDCOLORS
 
 from six.moves import xmlrpc_server # for the director services interface
 
+import atexit # for the killing server process after exit()
 
 KNOWN_VINS = ['111', '112', '113']
 
@@ -291,6 +292,9 @@ def host():
   print('Director repo serving on port: ' + str(demo.DIRECTOR_REPO_PORT))
   url = demo.DIRECTOR_REPO_HOST + ':' + str(demo.DIRECTOR_REPO_PORT) + '/'
   print('Director repo URL is: ' + url)
+
+  # Kill server process after calling exit().
+  atexit.register(kill_server)
 
   # Wait / allow any exceptions to kill the server.
   # try:

--- a/demo/demo_director.py
+++ b/demo/demo_director.py
@@ -59,7 +59,7 @@ from uptane import GREEN, RED, YELLOW, ENDCOLORS
 
 from six.moves import xmlrpc_server # for the director services interface
 
-import atexit # for the killing server process after exit()
+import atexit # to kill server process on exit()
 
 KNOWN_VINS = ['111', '112', '113']
 

--- a/demo/demo_oem_repo.py
+++ b/demo/demo_oem_repo.py
@@ -42,7 +42,7 @@ from uptane import GREEN, RED, YELLOW, ENDCOLORS
 
 from six.moves import xmlrpc_server # for the director services interface
 
-import atexit # for the killing server process after exit()
+import atexit # to kill server process on exit()
 
 repo = None
 server_process = None

--- a/demo/demo_oem_repo.py
+++ b/demo/demo_oem_repo.py
@@ -42,6 +42,7 @@ from uptane import GREEN, RED, YELLOW, ENDCOLORS
 
 from six.moves import xmlrpc_server # for the director services interface
 
+import atexit # for the killing server process after exit()
 
 repo = None
 server_process = None
@@ -210,6 +211,9 @@ def host():
   print('Main Repo serving on port: ' + str(demo.MAIN_REPO_PORT))
   url = demo.MAIN_REPO_HOST + ':' + str(demo.MAIN_REPO_PORT) + '/'
   print('Main Repo URL is: ' + url)
+
+  # Kill server process after calling exit()
+  atexit.register(kill_server)
 
   # Wait / allow any exceptions to kill the server.
   #try:

--- a/demo/demo_oem_repo.py
+++ b/demo/demo_oem_repo.py
@@ -212,7 +212,7 @@ def host():
   url = demo.MAIN_REPO_HOST + ':' + str(demo.MAIN_REPO_PORT) + '/'
   print('Main Repo URL is: ' + url)
 
-  # Kill server process after calling exit()
+  # Kill server process after calling exit().
   atexit.register(kill_server)
 
   # Wait / allow any exceptions to kill the server.


### PR DESCRIPTION
Fixes #29.

- Both cases (do.kill_server() and dd.kill_server()) used python atexit, which is exit handler. Called 
  atexit.register(kill_server) function inside of host() function.