### PR TITLE
Run cleanup routine after running the demo scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,6 @@ for software, hosting images and the metadata Uptane requires.
 import demo.demo_oem_repo as do
 do.clean_slate()
 ```
-After the demo, to end hosting:
-```python
-do.kill_server()
-```
 
 
 ### WINDOW 2: the Director
@@ -90,11 +86,6 @@ dd.write_to_live()
 ```
 As a result of the above, the Director will instruct ECU 11111 in vehicle 111 to install file5.txt. Since this file is not on (and validated by) the Image Repository, the Primary will refuse to download it (and a Full Verification Secondary would likewise refuse it even if a compromised Primary delivered it to the Secondary).
 
-After the demo, to end HTTP hosting (but not XMLRPC serving, which requires
-exiting the shell), do this (or else you'll have a zombie Python process to kill)
-```python
-dd.kill_server()
-```
 
 
 ### WINDOW 3: the Timeserver:

--- a/demo/__init__.py
+++ b/demo/__init__.py
@@ -104,3 +104,32 @@ def get_random_string(length):
       random.choice(string.ascii_uppercase + string.ascii_lowercase +
       string.digits) for i in range(length))
 
+
+def delete_temp_files(rm_type):
+  """
+  Function deletes temporary files after running demo.
+  """
+  if rm_type == "primary" or rm_type == "secondary":
+    # Remove temporary files in demo directory.
+    for subdir, dirs, files in os.walk(DEMO_DIR):
+      for file in files:
+        substring = ".json_" + file_type
+        if substring in file:
+          file_to_remove = DEMO_DIR + "/" + file
+          os.remove(file_to_remove)
+
+    # Remove temporary files in current directory.
+    for subdir, dirs, files in os.walk(uptane.WORKING_DIR):
+      for file in files:
+        substring = ".json_" + file_type
+        if substring in file:
+          file_to_remove = uptane.WORKING_DIR + "/" + file
+          os.remove(file_to_remove)
+
+  # Remove temporary directories.
+  if rm_type == "dir" or rm_type == "directory":
+    dir_to_remove = uptane.WORKING_DIR + "/director"
+    os.rmdir(dir_to_remove)
+    dir_to_remove = uptane.WORKING_DIR + "/mainrepo"
+    os.rmdir(dir_to_remove)
+

--- a/demo/demo_director.py
+++ b/demo/demo_director.py
@@ -59,6 +59,7 @@ from uptane import GREEN, RED, YELLOW, ENDCOLORS
 
 from six.moves import xmlrpc_server # for the director services interface
 
+import atexit # for the killing server process after exit()
 
 KNOWN_VINS = ['111', '112', '113']
 
@@ -291,6 +292,9 @@ def host():
   print('Director repo serving on port: ' + str(demo.DIRECTOR_REPO_PORT))
   url = demo.DIRECTOR_REPO_HOST + ':' + str(demo.DIRECTOR_REPO_PORT) + '/'
   print('Director repo URL is: ' + url)
+
+  # Kill server process after calling exit().
+  atexit.register(kill_server)
 
   # Wait / allow any exceptions to kill the server.
   # try:

--- a/demo/demo_oem_repo.py
+++ b/demo/demo_oem_repo.py
@@ -214,6 +214,8 @@ def host():
 
   # Kill server process after calling exit().
   atexit.register(kill_server)
+  # Delete temporary directories after demo exit().
+  atexit.register(delete_temp_files, "directory")
 
   # Wait / allow any exceptions to kill the server.
   #try:

--- a/demo/demo_oem_repo.py
+++ b/demo/demo_oem_repo.py
@@ -42,6 +42,7 @@ from uptane import GREEN, RED, YELLOW, ENDCOLORS
 
 from six.moves import xmlrpc_server # for the director services interface
 
+import atexit # for the killing server process after exit()
 
 repo = None
 server_process = None
@@ -210,6 +211,9 @@ def host():
   print('Main Repo serving on port: ' + str(demo.MAIN_REPO_PORT))
   url = demo.MAIN_REPO_HOST + ':' + str(demo.MAIN_REPO_PORT) + '/'
   print('Main Repo URL is: ' + url)
+
+  # Kill server process after calling exit()
+  atexit.register(kill_server)
 
   # Wait / allow any exceptions to kill the server.
   #try:

--- a/demo/demo_oem_repo.py
+++ b/demo/demo_oem_repo.py
@@ -212,7 +212,7 @@ def host():
   url = demo.MAIN_REPO_HOST + ':' + str(demo.MAIN_REPO_PORT) + '/'
   print('Main Repo URL is: ' + url)
 
-  # Kill server process after calling exit()
+  # Kill server process after calling exit().
   atexit.register(kill_server)
 
   # Wait / allow any exceptions to kill the server.

--- a/demo/demo_primary.py
+++ b/demo/demo_primary.py
@@ -44,6 +44,8 @@ from six.moves import xmlrpc_server
 from six.moves import range
 import socket # for socket.error, to catch listening failures from six's xmlrpc server
 
+import atexit # for the deleting temporary files after exit()
+
 # Import a CAN communications module for partial-verification Secondaries
 import ctypes
 libuptane_lib = None # will be loaded later if we are communicating via CAN
@@ -85,6 +87,10 @@ ecu_key = None
 director_proxy = None
 listener_thread = None
 most_recent_signed_vehicle_manifest = None
+
+
+# Delete temporary files after demo exit().
+atexit.register(delete_temp_files, "primary")
 
 
 def clean_slate(

--- a/demo/demo_secondary.py
+++ b/demo/demo_secondary.py
@@ -45,6 +45,11 @@ import canonicaljson
 
 from six.moves import xmlrpc_client
 
+import atexit # for the deleting temporary files after exit()
+
+# Delete temporary files after demo exit().
+atexit.register(delete_temp_files, "secondary")
+
 # Globals
 CLIENT_DIRECTORY_PREFIX = 'temp_secondary' # name for this secondary's directory
 client_directory = None


### PR DESCRIPTION
Fix #24 

- Add delete_temp_files() function which automatically cleans temporary files (primary and secondary).
  used python atexit, which is exit handler. Called atexit.register(delete_temp_files, "primary") function 
  inside in demo/demo_primary.py, atexit.register(delete_temp_files, "secondary") in 
  demo/demo_secondary.py and atexit.register(delete_temp_files, "directory") in demo/demo_oem_repo.py.

- Change README, basically removed dd.kill_server(), do.kill_server() and related comments