### PR TITLE
Adds 'mplayer' as demo audio player + updates docs (fix #25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ $ pip install -r dev-requirements.txt
 
 Note that the demonstration now operates using ASN.1 / DER format and encoding for metadata files by default. The TUF branch in use has been switched accordingly (so please run the command above again if you have an existing installation). This can be switched back to JSON (which is human readable) by changing the tuf.conf.METADATA_FORMAT option in uptane/__init__.py.
 
+### Install command-line audio player (optional)
+If you want the demo to play notification sounds you need one of the following audio player command line utilities on your path:
+- mplayer (available for all major operating systems)
+- omxplayer (built-in on Raspbian)
+- afplay (built-in on OS X)
 
 ## Running
 The code below is intended to be run in five or more consoles:

--- a/demo/uptane_sounds.py
+++ b/demo/uptane_sounds.py
@@ -55,6 +55,7 @@ def play(sound_path, blocking=False):
     at passed path.
 
     Tries to use one of the following players:
+      - mplayer (Linux)
       - omxplayer (Raspbian)
       - afplay (OS X)
 
@@ -78,14 +79,19 @@ def play(sound_path, blocking=False):
     print("Sound '{}' not found.".format(sound_path))
     return
 
-  if _on_path("omxplayer"):
+  if _on_path("mplayer"):
+    player = "mplayer"
+
+  elif _on_path("omxplayer"):
     player = "omxplayer"
 
   elif _on_path("afplay"):
     player = "afplay"
 
   else:
-    print("No player found on this platform.")
+    print("WARNING: No audio player found. To play demo sounds you need to"
+        " install one of 'omxplayer', 'mplayer' or 'afplay' command line"
+        " utilities.")
     return
 
   cmd = [player, sound_path]


### PR DESCRIPTION
To play demo notification sounds users need 'omxplayer' (Raspbian builtin) or 'afplay'  (OS X builtin) installed on their  path. This PR adds 'mplayer' (available for all major operating systems) to the list of possible CLI audio players for the demo.
Furthermore the PR adds optional audio player installation instructions to the demo README. 

Fixes #25 