### PR TITLE
Log whether or not the keyid matches in a VVM sig check

### DIFF
--- a/uptane/services/director.py
+++ b/uptane/services/director.py
@@ -377,7 +377,9 @@ class Director:
       log.info(
           'Key used to sign Vehicle Manifest has a different keyid from that '
           'listed in the inventory DB. Expect signature validation to fail, '
-          'unless the key is the same but the keyid differently hashed.')
+          'unless the key is the same but the keyid differently hashed. '
+          'Expected keyid: ' + repr(ecu_public_key['keyid']) + '; keyid used '
+          'in signature: ' + repr(keyid_used_in_signature))
 
 
     if tuf.conf.METADATA_FORMAT == 'der':

--- a/uptane/services/director.py
+++ b/uptane/services/director.py
@@ -6,7 +6,7 @@
   A core module that provides needed functionality for an Uptane-compliant
   Director. This CAN remain largely unchanged in real use. It is upon this that
   a full director is built to OEM specifications. A sample of such a Director
-  is in demo_director_svc.py.
+  is in demo/demo_director.py.
 
   Fundamentally, this code translates lists of vehicle software assignments
   (roughly mapping ECU IDs to targets) into signed metadata suitable for sending


### PR DESCRIPTION
When validating the Primary's signature on a Vehicle Version
Manifest, first check and see if the keyid provided in the
signature matches the keyid logged in the inventory database
for that Primary ECU, and if not, log a message indicating
that before proceeding to the signature validity check.

This is NOT security relevant. Code already tests whether
or not the signature is a valid signature by the correct
key. The only difference is that before, it was not clear
if the signature was from the wrong key instead of just
being a bad signature from the right key.