### PR TITLE
Fix JSON support in ECU and VVM processing

### DIFF
--- a/demo/demo_director.py
+++ b/demo/demo_director.py
@@ -407,9 +407,12 @@ def register_vehicle_manifest_wrapper(
   be extracted before it is passed to the underlying director.py (in the
   reference implementation), which doesn't know anything about XMLRPC.
   """
-  director_service_instance.register_vehicle_manifest(
-      vin, primary_ecu_serial, signed_vehicle_manifest.data)
-
+  if tuf.conf.METADATA_FORMAT == 'der':
+    director_service_instance.register_vehicle_manifest(
+        vin, primary_ecu_serial, signed_vehicle_manifest.data)
+  else:
+    director_service_instance.register_vehicle_manifest(
+        vin, primary_ecu_serial, signed_vehicle_manifest)
 
 
 

--- a/demo/demo_primary.py
+++ b/demo/demo_primary.py
@@ -780,8 +780,12 @@ def register_ecu_manifest_wrapper(vin, ecu_serial, nonce, signed_ecu_manifest):
   be extracted before it is passed to the underlying primary.py (in the
   reference implementation), which doesn't know anything about XMLRPC.
   """
-  primary_ecu.register_ecu_manifest(
-      vin, ecu_serial, nonce, signed_ecu_manifest.data)
+  if tuf.conf.METADATA_FORMAT == 'der':
+    primary_ecu.register_ecu_manifest(
+        vin, ecu_serial, nonce, signed_ecu_manifest.data)
+  else:
+    primary_ecu.register_ecu_manifest(
+        vin, ecu_serial, nonce, signed_ecu_manifest)
 
 
 

--- a/uptane/services/director.py
+++ b/uptane/services/director.py
@@ -391,16 +391,18 @@ class Director:
       data_to_check = asn1_codec.convert_signed_metadata_to_der(
           vehicle_manifest, only_signed=True, datatype='vehicle_manifest')
       data_to_check = hashlib.sha256(data_to_check).digest()
+      is_binary_data = True
 
     else:
       data_to_check = vehicle_manifest['signed']
+      is_binary_data = False
 
 
     valid = tuf.keys.verify_signature(
         ecu_public_key,
         vehicle_manifest['signatures'][0], # TODO: Fix assumptions.
         data_to_check,
-        is_binary_data=True)
+        is_binary_data=is_binary_data)
 
     if not valid:
       log.debug(

--- a/uptane/services/director.py
+++ b/uptane/services/director.py
@@ -203,15 +203,17 @@ class Director:
       data_to_check = asn1_codec.convert_signed_metadata_to_der(
           signed_ecu_manifest, only_signed=True, datatype='ecu_manifest')
       data_to_check = hashlib.sha256(data_to_check).digest()
+      is_binary_data = True
 
     else:
       data_to_check = signed_ecu_manifest['signed']
+      is_binary_data = False
 
     valid = tuf.keys.verify_signature(
         ecu_public_key,
         signed_ecu_manifest['signatures'][0], # TODO: Fix assumptions.
         data_to_check,
-        is_binary_data=True)
+        is_binary_data=is_binary_data)
 
     if not valid:
       log.info(


### PR DESCRIPTION
When Vehicle Version Manifest support for ASN.1/DER was added and ASN.1/DER was made the default for these, there were a few bugs introduced in JSON-based Vehicle Version Manifest processing.

For example, the VVM receiving wrapper added to the demo for DER support should have a conditional around the code for taking the binary data out of the XML-RPC object used in case DER data is transferred via XML-RPC, so that it doesn't break JSON processing if we're using JSON.

Note that automated testing running for both JSON and DER modes (instead of just whatever the default is) would have caught this. See Issue #72.