### PR TITLE
Implement and Fix issues #63 and #69

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,7 +463,7 @@ while in control. In this demo, these two things are done like so:
 
 In the **Image** repository window:
 ```
->>> di.revoke_and_add_new_keys_and_write_to_live()
+>>> di.revoke_compromised_keys()
 >>> di.add_target_and_write_to_live(filename='firmware.img',
         file_content='Fresh firmware image')
 ```

--- a/README.md
+++ b/README.md
@@ -429,10 +429,11 @@ On the **secondary** client:
 >>> ds.update_cycle()
 ```
 
-Note, both the image and director repositories have been compromised.  The primary installs the
-*firmware.img*, however, the secondary does not.  Unfortunately, an attack of this kind,
-where all available repositories are compromised, would not be blocked in practice because both
-director and image repositories are compromised.
+Note, both the image and director repositories have been compromised. As a
+result, unfortuantely, in an attack of this kind Secondary would install this
+malicious firmware.img, which neither the Primary nor the
+Secondary have any way of knowing is malicious, since every necessary key has
+signed metadata for that image.
 
 For demonstration purposes, the secondary detects that a malicious file is installed.  The secondary
 client in the demo code prints a banner indicating that the *firmware.img* image was malicously

--- a/README.md
+++ b/README.md
@@ -504,7 +504,13 @@ attacker.
 
 ### 3.7: Arbitrary Package Attack with Revoked Keys
 
-Generate metadata signed with the keys revoked in the previous section.
+We should verify that the Primary does indeed reject metadata that's been
+signed with revoked keys.  As noted in the previous section, the Primary and
+secondaries automatically remove trust in revoked keys when they install the
+new Root metadata.
+
+Let's begin the demonstration by generating metadata that is maliciously
+signed with the keys revoked in the last section.
 
 ```Python
 >>> dd.sign_with_compromised_keys_attack()
@@ -517,10 +523,11 @@ The Primary attempts to download the maliciously-signed metadata...
 >>> dp.update_cycle()
 ```
 
-... and detects a bad signature on it by displaying a DEFENDED banner.  The
-Primary does not trust the keys used to sign the metadata, as expected.  If you
-were to inspect the cause of the download failure, you'd find the following
-exception:
+... and detects a bad signature by displaying a DEFENDED banner.  The Primary
+does not trust the keys and signature specified in the metadata, as expected.
+If you were to inspect the cause of the download failure, you'd find the
+following exception:
+
 ```
 Downloading: u'http://localhost:30401/111/metadata/timestamp.der'
 Downloaded 202 bytes out of an upper limit of 16384 bytes.
@@ -532,9 +539,9 @@ Failed to update timestamp.der from all mirrors: {u'http://localhost:30401/111/m
 Valid top-level metadata cannot be downloaded.  Unsafely update the Root metadata.
 ```
 
-Restore metadata to the previously trusted state, where the compromised keys
-had been revoked and new keys were added for the Targets, Snapshot, and
-Timestamp roles.
+We next restore metadata to the previously trusted state, where the compromised
+keys had been revoked and where new keys were added for the Targets, Snapshot,
+and Timestamp roles.
 
 ```Python
 >>> dd.undo_sign_with_compromised_keys_attack()
@@ -546,7 +553,7 @@ have been saved by the Primary.
 
 
 ```Python
-# This call should indicate that the client is up-to-date
+# This call should indicate that the client is up-to-date.
 >>> dp.update_cycle()
 ```
 

--- a/README.md
+++ b/README.md
@@ -547,7 +547,7 @@ and Timestamp roles.
 >>> dd.undo_sign_with_compromised_keys_attack()
 ```
 
-If the Primary performs an update cycle once again, it would appear to be
+If the Primary initiates an update cycle once again, it would appear to be
 up-to-date.  The metadata that was signed by the revoked keys should not
 have been saved by the Primary.
 

--- a/README.md
+++ b/README.md
@@ -469,7 +469,7 @@ In the **Image** repository window:
 
 And in the **Director** repository window:
 ```
->>> dd.revoke_and_add_new_keys_and_write_to_live(prefix_of_new_keys='new_')
+>>> dd.revoke_compromised_keys()
 >>> dd.add_target_and_write_to_live(filename='firmware.img',
     file_content='Fresh firmware image', vin='111', ecu_serial='22222')
 ```
@@ -507,7 +507,7 @@ attacker.
 Generate metadata signed with the keys revoked in the previous section.
 
 ```Python
->>> dd.write_to_live_with_previous_keys(prefix_of_previous_keys=None)
+>>> dd.sign_with_compromised_keys_attack()
 ```
 
 
@@ -537,7 +537,7 @@ had been revoked and new keys were added for the Targets, Snapshot, and
 Timestamp roles.
 
 ```Python
->>> dd.undo_write_to_live_with_previous_keys(prefix_of_valid_keys='new_')
+>>> dd.undo_sign_with_compromised_keys_attack()
 ```
 
 If the Primary performs an update cycle once again, it would appear to be
@@ -549,6 +549,4 @@ have been saved by the Primary.
 # This call should indicate that the client is up-to-date
 >>> dp.update_cycle()
 ```
-
-
 

--- a/README.md
+++ b/README.md
@@ -507,19 +507,20 @@ attacker.
 Generate metadata signed with the keys revoked in the previous section.
 
 ```Python
-dd.write_to_live_with_previous_keys(prefix_of_previous_keys=None)
+>>> dd.write_to_live_with_previous_keys(prefix_of_previous_keys=None)
 ```
 
 
 The Primary attempts to download the maliciously-signed metadata...
 
 ```Python
-dp.update_cycle()
+>>> dp.update_cycle()
 ```
 
-and detects a bad signature on it.  The Primary does not trust the key
-used to sign the metadata, as expected.  If you were to inspect the cause of
-the download failure, you'd find the following exception:
+... and detects a bad signature on it by displaying a DEFENDED banner.  The
+Primary does not trust the keys used to sign the metadata, as expected.  If you
+were to inspect the cause of the download failure, you'd find the following
+exception:
 ```
 Downloading: u'http://localhost:30401/111/metadata/timestamp.der'
 Downloaded 202 bytes out of an upper limit of 16384 bytes.
@@ -536,7 +537,7 @@ had been revoked and new keys were added for the Targets, Snapshot, and
 Timestamp roles.
 
 ```Python
-dd.undo_write_to_live_with_previous_keys(prefix_of_valid_keys='new_')
+>>> dd.undo_write_to_live_with_previous_keys(prefix_of_valid_keys='new_')
 ```
 
 If the Primary performs an update cycle once again, it would appear to be
@@ -546,7 +547,7 @@ have been saved by the Primary.
 
 ```Python
 # This call should indicate that the client is up-to-date
-dp.update_cycle()
+>>> dp.update_cycle()
 ```
 
 

--- a/demo/demo_director.py
+++ b/demo/demo_director.py
@@ -387,7 +387,7 @@ def undo_sign_with_compromised_keys_attack():
   """
   <Purpose>
     Undo the actions executed by sign_with_compromised_keys_attack().  Namely,
-    move the valid metadata into the live and metadat.staged directories, and
+    move the valid metadata into the live and metadata.staged directories, and
     reload the valid keys for each repository.
 
   <Arguments>

--- a/demo/demo_director.py
+++ b/demo/demo_director.py
@@ -328,6 +328,7 @@ def sign_with_compromised_keys_attack():
 
   global director_service_instance
 
+  # Load the now-revoked keys.
   old_targets_private_key = demo.import_private_key('director')
   old_timestamp_private_key = demo.import_private_key('directortimestamp')
   old_snapshot_private_key = demo.import_private_key('directorsnapshot')
@@ -336,8 +337,7 @@ def sign_with_compromised_keys_attack():
   current_timestamp_private_key = director_service_instance.key_dirtime_pri
   current_snapshot_private_key = director_service_instance.key_dirsnap_pri
 
-  # Set the new private keys in the director service.  These keys are shared
-  # between all vehicle repositories.
+  # Ensure the director service uses the old (now-revoked) keys.
   director_service_instance.key_dirtarg_pri = old_targets_private_key
   director_service_instance.key_dirtime_pri = old_timestamp_private_key
   director_service_instance.key_dirsnap_pri = old_snapshot_private_key

--- a/demo/demo_director.py
+++ b/demo/demo_director.py
@@ -439,8 +439,11 @@ def undo_sign_with_compromised_keys_attack():
     os.rename(os.path.join(repo_dir, 'metadata.backup'),
         os.path.join(repo_dir, 'metadata.staged'))
 
-    # Re-load the restored metadata.stated directory.
-    repository = rt.load_repository(repo_dir)
+    # Re-load the repository from the restored metadata.stated directory.
+    # (We're using a temp variable here, so we have to assign the new reference
+    # to both the temp and the source variable.)
+    director_service_instance.vehicle_repositories[vin] = repository = \
+        rt.load_repository(repo_dir)
 
     # Load the new signing keys to write metadata. The root key is unchanged,
     # but must be reloaded because load_repository() was called.

--- a/demo/demo_director.py
+++ b/demo/demo_director.py
@@ -200,7 +200,7 @@ def write_to_live(vin_to_update=None, backup_repo=False):
 
 
 
-def revoke_and_add_new_keys_and_write_to_live():
+def revoke_compromised_keys():
   """
   <Purpose>
     Revoke the current Timestamp, Snapshot, and Targets keys for all vehicles
@@ -294,7 +294,7 @@ def revoke_and_add_new_keys_and_write_to_live():
 
 
 
-def write_to_live_with_previous_keys():
+def sign_with_compromised_keys_attack():
   """
   <Purpose>
     Re-generate Timestamp, Snapshot, and Targets metadata for all vehicles and
@@ -375,10 +375,10 @@ def write_to_live_with_previous_keys():
 
 
 
-def undo_write_to_live_with_previous_keys():
+def undo_sign_with_compromised_keys_attack():
   """
   <Purpose>
-    Undo the actions executed by write_to_live_with_previous_keys().  Namely,
+    Undo the actions executed by sign_with_compromised_keys_attack().  Namely,
     move the valid metadata into the live and staged directories, and reload
     the valid keys for each repository.
 

--- a/demo/demo_director.py
+++ b/demo/demo_director.py
@@ -200,7 +200,7 @@ def write_to_live(vin_to_update=None, backup_repo=False):
 
 
 
-def revoke_and_add_new_keys_and_write_to_live(prefix_of_new_keys=None):
+def revoke_and_add_new_keys_and_write_to_live():
   """
   <Purpose>
     Revoke the current Timestamp, Snapshot, and Targets keys for all vehicles
@@ -209,11 +209,7 @@ def revoke_and_add_new_keys_and_write_to_live(prefix_of_new_keys=None):
     updated with the key changes.
 
   <Arguments>
-    prefix_of_new_keys:
-      A prefix that is optionally prepended to the default names of the key
-      files.  For example: if prefix_of_new_keys = 'new_', new keyfiles would be
-      named 'new_director', 'new_directorsnapshot', and
-      'new_directortimestamp'.
+    None.
 
   <Exceptions>
     None.
@@ -231,24 +227,25 @@ def revoke_and_add_new_keys_and_write_to_live(prefix_of_new_keys=None):
   # service instance is updated to use the new key.  'director' name
   # actually references the targets role.
   # TODO: Change Director's targets key to 'directortargets' from 'director'.
-  if prefix_of_new_keys is None:
-    prefix_of_new_keys = ''
+  new_targets_keyname = 'new_director'
+  new_timestamp_keyname = 'new_directortimestamp'
+  new_snapshot_keyname = 'new_directorsnapshot'
 
-  demo.generate_key(prefix_of_new_keys + 'director')
-  new_targets_public_key = demo.import_public_key(prefix_of_new_keys + 'director')
-  new_targets_private_key = demo.import_private_key(prefix_of_new_keys + 'director')
+  demo.generate_key(new_targets_keyname)
+  new_targets_public_key = demo.import_public_key(new_targets_keyname)
+  new_targets_private_key = demo.import_private_key(new_targets_keyname)
   old_targets_public_key = director_service_instance.key_dirtarg_pub
   old_targets_private_key = director_service_instance.key_dirtarg_pri
 
-  demo.generate_key(prefix_of_new_keys + 'directortimestamp')
-  new_timestamp_public_key = demo.import_public_key(prefix_of_new_keys + 'directortimestamp')
-  new_timestamp_private_key = demo.import_private_key(prefix_of_new_keys + 'directortimestamp')
+  demo.generate_key(new_timestamp_keyname)
+  new_timestamp_public_key = demo.import_public_key(new_timestamp_keyname)
+  new_timestamp_private_key = demo.import_private_key(new_timestamp_keyname)
   old_timestamp_public_key = director_service_instance.key_dirtime_pub
   old_timestamp_private_key = director_service_instance.key_dirtime_pri
 
-  demo.generate_key(prefix_of_new_keys + 'directorsnapshot')
-  new_snapshot_public_key = demo.import_public_key(prefix_of_new_keys + 'directorsnapshot')
-  new_snapshot_private_key = demo.import_private_key(prefix_of_new_keys + 'directorsnapshot')
+  demo.generate_key(new_snapshot_keyname)
+  new_snapshot_public_key = demo.import_public_key(new_snapshot_keyname)
+  new_snapshot_private_key = demo.import_private_key(new_snapshot_keyname)
   old_snapshot_public_key = director_service_instance.key_dirsnap_pub
   old_snapshot_private_key = director_service_instance.key_dirsnap_pri
 
@@ -297,7 +294,7 @@ def revoke_and_add_new_keys_and_write_to_live(prefix_of_new_keys=None):
 
 
 
-def write_to_live_with_previous_keys(prefix_of_previous_keys=None):
+def write_to_live_with_previous_keys():
   """
   <Purpose>
     Re-generate Timestamp, Snapshot, and Targets metadata for all vehicles and
@@ -309,10 +306,7 @@ def write_to_live_with_previous_keys(prefix_of_previous_keys=None):
     instance is also updated with the key changes.
 
   <Arguments>
-    prefix_of_previous_keys:
-      If not None, the previous keys with names prefix_of_previous_keys+director,
-      prefix_of_previous_keys+directorsnapshot, etc., are loaded to sign the new
-      Timestamp, Snapshot, and Targets metadata.
+    None.
 
   <Side Effects>
     None.
@@ -326,12 +320,9 @@ def write_to_live_with_previous_keys(prefix_of_previous_keys=None):
 
   global director_service_instance
 
-  if prefix_of_previous_keys is None:
-    prefix_of_previous_keys = ''
-
-  old_targets_private_key = demo.import_private_key(prefix_of_previous_keys + 'director')
-  old_timestamp_private_key = demo.import_private_key(prefix_of_previous_keys + 'directortimestamp')
-  old_snapshot_private_key = demo.import_private_key(prefix_of_previous_keys + 'directorsnapshot')
+  old_targets_private_key = demo.import_private_key('director')
+  old_timestamp_private_key = demo.import_private_key('directortimestamp')
+  old_snapshot_private_key = demo.import_private_key('directorsnapshot')
 
   current_targets_private_key = director_service_instance.key_dirtarg_pri
   current_timestamp_private_key = director_service_instance.key_dirtime_pri
@@ -384,7 +375,7 @@ def write_to_live_with_previous_keys(prefix_of_previous_keys=None):
 
 
 
-def undo_write_to_live_with_previous_keys(prefix_of_valid_keys=None):
+def undo_write_to_live_with_previous_keys():
   """
   <Purpose>
     Undo the actions executed by write_to_live_with_previous_keys().  Namely,
@@ -392,9 +383,7 @@ def undo_write_to_live_with_previous_keys(prefix_of_valid_keys=None):
     the valid keys for each repository.
 
   <Arguments>
-    prefix_of_valid_keys:
-      The previous keys prepended with this prefix are reloaded for each
-      repository.
+    None.
 
   <Side Effects>
     None.
@@ -408,12 +397,10 @@ def undo_write_to_live_with_previous_keys(prefix_of_valid_keys=None):
 
   global director_service_instance
 
-  if prefix_of_valid_keys is None:
-    prefix_of_valid_keys = ''
 
-  valid_targets_private_key = demo.import_private_key(prefix_of_valid_keys + 'director')
-  valid_timestamp_private_key = demo.import_private_key(prefix_of_valid_keys + 'directortimestamp')
-  valid_snapshot_private_key = demo.import_private_key(prefix_of_valid_keys + 'directorsnapshot')
+  valid_targets_private_key = demo.import_private_key('new_director')
+  valid_timestamp_private_key = demo.import_private_key('new_directortimestamp')
+  valid_snapshot_private_key = demo.import_private_key('new_directorsnapshot')
 
   current_targets_private_key = director_service_instance.key_dirtarg_pri
   current_timestamp_private_key = director_service_instance.key_dirtime_pri

--- a/demo/demo_director.py
+++ b/demo/demo_director.py
@@ -444,11 +444,6 @@ def undo_write_to_live_with_previous_keys(prefix_of_valid_keys=None):
 
     repository = rt.load_repository(repo_dir)
 
-    """
-    repository.targets.unload_signing_key(current_targets_private_key)
-    repository.snapshot.unload_signing_key(current_snapshot_private_key)
-    repository.timestamp.unload_signing_key(current_timestamp_private_key)
-    """
     # Load the new signing keys to write metadata. The root key is unchanged,
     # and in the demo it is already loaded.
 

--- a/demo/demo_director.py
+++ b/demo/demo_director.py
@@ -353,8 +353,8 @@ def sign_with_compromised_keys_attack():
     repository.snapshot.unload_signing_key(current_snapshot_private_key)
     repository.timestamp.unload_signing_key(current_timestamp_private_key)
 
-    # Load the new signing keys to write metadata. The root key is unchanged,
-    # and in the demo it is already loaded.
+    # Load the old signing keys to generate the malicious metadata. The root
+    # key is unchanged, and in the demo it is already loaded.
     repository.targets.load_signing_key(old_targets_private_key)
     repository.snapshot.load_signing_key(old_snapshot_private_key)
     repository.timestamp.load_signing_key(old_timestamp_private_key)

--- a/demo/demo_director.py
+++ b/demo/demo_director.py
@@ -387,8 +387,8 @@ def undo_sign_with_compromised_keys_attack():
   """
   <Purpose>
     Undo the actions executed by sign_with_compromised_keys_attack().  Namely,
-    move the valid metadata into the live and staged directories, and reload
-    the valid keys for each repository.
+    move the valid metadata into the live and metadat.staged directories, and
+    reload the valid keys for each repository.
 
   <Arguments>
     None.
@@ -406,6 +406,8 @@ def undo_sign_with_compromised_keys_attack():
   global director_service_instance
 
 
+  # Re-load the valid keys, so that the repository objects can be updated to
+  # reference them and replace the compromised keys set.
   valid_targets_private_key = demo.import_private_key('new_director')
   valid_timestamp_private_key = demo.import_private_key('new_directortimestamp')
   valid_snapshot_private_key = demo.import_private_key('new_directorsnapshot')
@@ -425,9 +427,9 @@ def undo_sign_with_compromised_keys_attack():
     repository = director_service_instance.vehicle_repositories[vin]
     repo_dir = repository._repository_directory
 
-    # Copy the backup metadata to the staged and live directories.  The backup
-    # metadata should already exist if write_to_live_with_previous_keys() was
-    # called.
+    # Copy the backup metadata to the metada.staged and live directories.  The
+    # backup metadata should already exist if
+    # sign_with_compromised_keys_attack() was called.
 
     # Empty the existing (old) live metadata directory (relatively fast).
     if os.path.exists(os.path.join(repo_dir, 'metadata.staged')):
@@ -437,18 +439,18 @@ def undo_sign_with_compromised_keys_attack():
     os.rename(os.path.join(repo_dir, 'metadata.backup'),
         os.path.join(repo_dir, 'metadata.staged'))
 
+    # Re-load the restored metadata.stated directory.
     repository = rt.load_repository(repo_dir)
 
     # Load the new signing keys to write metadata. The root key is unchanged,
-    # and in the demo it is already loaded.
-
+    # but must be reloaded because load_repository() was called.
     valid_root_private_key = demo.import_private_key('directorroot')
     repository.root.load_signing_key(valid_root_private_key)
     repository.targets.load_signing_key(valid_targets_private_key)
     repository.snapshot.load_signing_key(valid_snapshot_private_key)
     repository.timestamp.load_signing_key(valid_timestamp_private_key)
 
-    # Copy the staged metadata to a temp directory we'll move into place
+    # Copy the staged metadata to a temp directory, which we'll move into place
     # atomically in a moment.
     shutil.copytree(os.path.join(repo_dir, 'metadata.staged'),
         os.path.join(repo_dir, 'metadata.livetemp'))

--- a/demo/demo_image_repo.py
+++ b/demo/demo_image_repo.py
@@ -367,7 +367,7 @@ def add_target_and_write_to_live(filename, file_content):
 
 
 
-def revoke_and_add_new_keys_and_write_to_live():
+def revoke_compromised_keys():
   """
   <Purpose>
     Revoke the current Timestamp, Snapshot, and Targets keys, and add a new keys

--- a/demo/demo_primary.py
+++ b/demo/demo_primary.py
@@ -330,9 +330,9 @@ def update_cycle():
     primary_ecu.primary_update_cycle()
 
   # Print a REPLAY or DEFENDED banner if ReplayedMetadataError or
-  # BadSignatureError are raised by primary_update_cycle().  These banners
-  # are strictly triggered in demo for bad Timestamp metadata, and all others
-  # should be re-raised.
+  # BadSignatureError is raised by primary_update_cycle().  These banners are
+  # only triggered for bad Timestamp metadata, and all other exception are
+  # re-raised.
   except tuf.NoWorkingMirrorError as exception:
     director_file = os.path.join(_vin, 'metadata', 'timestamp' + demo.METADATA_EXTENSION)
     for mirror_url in exception.mirror_errors:
@@ -341,12 +341,12 @@ def update_cycle():
           print_banner(BANNER_REPLAY, color=WHITE+BLACK_BG,
               text='The Director has instructed us to download a Timestamp'
               ' that is older than the currently trusted version. This'
-              ' instruction has been rejected.', sound=SATAN)
+              ' instruction has been rejected.', sound=TADA)
 
         elif isinstance(exception.mirror_errors[mirror_url], tuf.BadSignatureError):
           print_banner(BANNER_DEFENDED, color=WHITE+GREEN_BG,
               text='The Director has instructed us to download a Timestamp'
-              ' signed with keys that are untrusted.  This metadata has'
+              ' that is signed with keys that are untrusted.  This metadata has'
               ' been rejected.', sound=TADA)
 
         else:

--- a/demo/demo_primary.py
+++ b/demo/demo_primary.py
@@ -344,7 +344,7 @@ def update_cycle():
               ' instruction has been rejected.', sound=TADA)
 
         elif isinstance(exception.mirror_errors[mirror_url], tuf.BadSignatureError):
-          print_banner(BANNER_DEFENDED, color=WHITE+GREEN_BG,
+          print_banner(BANNER_DEFENDED, color=WHITE+DARK_BLUE_BG,
               text='The Director has instructed us to download a Timestamp'
               ' that is signed with keys that are untrusted.  This metadata has'
               ' been rejected.', sound=TADA)

--- a/demo/demo_primary.py
+++ b/demo/demo_primary.py
@@ -329,10 +329,10 @@ def update_cycle():
   try:
     primary_ecu.primary_update_cycle()
 
-  # Print a REPLAY banner if ReplayedMetadataError is raised by
-  # primary_update_cycle() while performing an update from the director
-  # repository.  This banner is strictly a demo check for replayed metadata for
-  # Timestamp metadata, and all others should be re-raised.
+  # Print a REPLAY or DEFENDED banner if ReplayedMetadataError or
+  # BadSignatureError are raised by primary_update_cycle().  These banners
+  # are strictly triggered in demo for bad Timestamp metadata, and all others
+  # should be re-raised.
   except tuf.NoWorkingMirrorError as exception:
     director_file = os.path.join(_vin, 'metadata', 'timestamp' + demo.METADATA_EXTENSION)
     for mirror_url in exception.mirror_errors:
@@ -340,8 +340,14 @@ def update_cycle():
         if isinstance(exception.mirror_errors[mirror_url], tuf.ReplayedMetadataError):
           print_banner(BANNER_REPLAY, color=WHITE+BLACK_BG,
               text='The Director has instructed us to download a Timestamp'
-              ' that is older than the currently trusted version. This '
-              'instruction has been rejected.', sound=SATAN)
+              ' that is older than the currently trusted version. This'
+              ' instruction has been rejected.', sound=SATAN)
+
+        elif isinstance(exception.mirror_errors[mirror_url], tuf.BadSignatureError):
+          print_banner(BANNER_DEFENDED, color=WHITE+GREEN_BG,
+              text='The Director has instructed us to download a Timestamp'
+              ' signed with keys that are untrusted.  This metadata has'
+              ' been rejected.', sound=TADA)
 
         else:
           raise


### PR DESCRIPTION
This final attack for the demo shows that the primary rejects metadata that is signed with revoked keys.
Fix and implementation of issues #63 and #69.

TODO for this pull request:
* [x] Display a banner for UnsignedMetadataError
* [x] Polish the text explaining the attack (in the README)
* [x] Receive feedback on approach before polishing the code