### PR TITLE
Refactor signature code

### DIFF
--- a/demo/demo_director.py
+++ b/demo/demo_director.py
@@ -407,9 +407,12 @@ def register_vehicle_manifest_wrapper(
   be extracted before it is passed to the underlying director.py (in the
   reference implementation), which doesn't know anything about XMLRPC.
   """
-  director_service_instance.register_vehicle_manifest(
-      vin, primary_ecu_serial, signed_vehicle_manifest.data)
-
+  if tuf.conf.METADATA_FORMAT == 'der':
+    director_service_instance.register_vehicle_manifest(
+        vin, primary_ecu_serial, signed_vehicle_manifest.data)
+  else:
+    director_service_instance.register_vehicle_manifest(
+        vin, primary_ecu_serial, signed_vehicle_manifest)
 
 
 

--- a/demo/demo_primary.py
+++ b/demo/demo_primary.py
@@ -780,8 +780,12 @@ def register_ecu_manifest_wrapper(vin, ecu_serial, nonce, signed_ecu_manifest):
   be extracted before it is passed to the underlying primary.py (in the
   reference implementation), which doesn't know anything about XMLRPC.
   """
-  primary_ecu.register_ecu_manifest(
-      vin, ecu_serial, nonce, signed_ecu_manifest.data)
+  if tuf.conf.METADATA_FORMAT == 'der':
+    primary_ecu.register_ecu_manifest(
+        vin, ecu_serial, nonce, signed_ecu_manifest.data)
+  else:
+    primary_ecu.register_ecu_manifest(
+        vin, ecu_serial, nonce, signed_ecu_manifest)
 
 
 

--- a/demo/demo_timeserver.py
+++ b/demo/demo_timeserver.py
@@ -126,11 +126,12 @@ def test_demo_timeserver():
   signed_time = timeserver.get_signed_time([1, 2])
 
   assert len(signed_time['signatures']) == 1, 'Unexpected number of signatures.'
-  assert tuf.keys.verify_signature(
+  assert uptane.common.verify_signature_over_metadata(
       timeserver_key_pub,
       signed_time['signatures'][0],
       signed_time['signed'],
-      force_treat_as_pydict=True
+      datatype='time_attestation',
+      metadata_format='json'
       ), 'Demo Timeserver self-test fail: unable to verify signature over JSON.'
 
 
@@ -149,15 +150,13 @@ def test_demo_timeserver():
   for pydict_again in [
       asn1_codec.convert_signed_der_to_dersigned_json(der_signed_time),
       asn1_codec.convert_signed_der_to_dersigned_json(xb_der_signed_time.data)]:
-    der_signed = asn1_codec.convert_signed_metadata_to_der(
-          pydict_again, only_signed=True)
-    der_signed_hash = hashlib.sha256(der_signed).digest()
-    assert tuf.keys.verify_signature(
+
+    assert uptane.common.verify_signature_over_metadata(
         timeserver_key_pub,
         pydict_again['signatures'][0],
-        der_signed_hash,
-        is_binary_data=True,
-        force_non_json=True
+        pydict_again['signed'],
+        datatype='time_attestation',
+        metadata_format='der'
         ), 'Demo Timeserver self-test fail: unable to verify signature over DER'
 
 

--- a/tests/test_primary.py
+++ b/tests/test_primary.py
@@ -487,16 +487,10 @@ class TestPrimary(unittest.TestCase):
       uptane.formats.DER_DATA_SCHEMA.check_match(vehicle_manifest)
       vehicle_manifest = asn1_codec.convert_signed_der_to_dersigned_json(
           vehicle_manifest, datatype='vehicle_manifest')
-      data_to_verify = hashlib.sha256(asn1_codec.convert_signed_metadata_to_der(
-          vehicle_manifest, only_signed=True, datatype='vehicle_manifest')
-          ).digest()
-      is_binary_data = True   # for keys.verify_signature
 
     else:
       uptane.formats.SIGNABLE_VEHICLE_VERSION_MANIFEST_SCHEMA.check_match(
           vehicle_manifest)
-      data_to_verify = vehicle_manifest['signed']
-      is_binary_data = False  # for keys.verify_signature
 
     # Test contents of vehicle manifest.
     # Make sure there is exactly one signature.
@@ -512,11 +506,11 @@ class TestPrimary(unittest.TestCase):
     # Check the signature on the vehicle manifest.
     # tuf.keys needs to know not to try encoding the data as UTF-8 if we're
     # working with DER and data_to_verify is already bytes.
-    self.assertTrue(tuf.keys.verify_signature(
+    self.assertTrue(uptane.common.verify_signature_over_metadata(
         primary_ecu_key,
         vehicle_manifest['signatures'][0], # TODO: Deal with 1-sig assumption?
-        data_to_verify,
-        is_binary_data=is_binary_data))
+        vehicle_manifest['signed'],
+        datatype='vehicle_manifest'))
 
 
 

--- a/uptane/common.py
+++ b/uptane/common.py
@@ -105,10 +105,8 @@ def sign_signable(
     # We should already be guaranteed to have a supported key type due to
     # the ANYKEY_SCHEMA.check_match call above. Defensive programming.
     if signing_key['keytype'] not in SUPPORTED_KEY_TYPES:
-      assert False, 'Programming error: key types have already been ' + \
-          'validated; should not be possible that we now have an ' + \
-          'unsupported key type, but we do: ' + repr(signing_key['keytype'])
-
+      raise uptane.Error(
+          'Unsupported key type: ' + repr(signing_key['keytype']))
 
     # Else, all is well. Sign the signable with the given key, adding that
     # signature to the signatures list in the signable.

--- a/uptane/common.py
+++ b/uptane/common.py
@@ -21,6 +21,9 @@ import uptane.encoding.asn1_codec as asn1_codec
 import uptane
 import uptane.formats
 
+# Both key types below are supported, but issues may be encountered with RSA
+# if tuf.conf.METADATA_FORMAT is 'der' (rather than 'json').
+# TODO: Ensure RSA support in ASN.1/DER conversion.
 SUPPORTED_KEY_TYPES = ['ed25519', 'rsa']
 
 def sign_signable(
@@ -73,7 +76,9 @@ def sign_signable(
 
   <Exceptions>
     tuf.FormatError if the provided key is not the correct format or lacks a
-    private element, or if the signing key type is not the .
+    private element.
+
+    uptane.Error if the key type is not in the SUPPORTED_KEY_TYPES for Uptane.
 
   <Side Effects>
     Adds a signature to the provided signable.

--- a/uptane/common.py
+++ b/uptane/common.py
@@ -11,6 +11,13 @@ import json
 import os
 import shutil
 import copy
+import hashlib
+
+# TODO: This import is not ideal at this level. Common should probably not
+# import anything from other Uptane modules. Consider putting the
+# signature-related functions into a new module (sig or something) that
+# imports asn1_codec.
+import uptane.encoding.asn1_codec as asn1_codec
 
 SUPPORTED_KEY_TYPES = ['ed25519', 'rsa']
 
@@ -77,6 +84,125 @@ def sign_signable(signable, keys_to_sign_with):
   #tuf.formats.check_signable_object_format(signable)
 
   return signable # Fully signed
+
+
+def sign_over_metadata(
+    key_dict, data, datatype, metadata_format=tuf.conf.METADATA_FORMAT):
+  """
+  Almost exactly identical to the function simultaneously added to TUF,
+  tuf.sig.sign_over_metadata(). Requires datatype.
+  Must differ in Uptane simply because it is not possible to convert
+  Uptane-specific metadata (Time Attestations, ECU Manifests, and Vehicle
+  Manifests) to or from ASN.1/DER without knowing which of those three
+  types of metadata you're dealign with, and this conversion is required for
+  signing and verifying signatures.
+
+  Higher level function that wraps tuf.keys.create_signature, and works
+  specifically with Time Attestations, ECU Manifsts, and Vehicle Manifests that
+  will be in JSON or ASN.1/DER format.
+
+  See tuf.keys.create_signature for overall functionality and the arguments
+  key_dict and data.
+
+  Optional argument:
+
+    metadata_format: (optional; default based on tuf.conf.METADATA_FORMAT)
+
+      If 'json', treats data as a JSON-friendly Python dictionary to be turned
+      into a canonical JSON string and then encoded as utf-8 before signing.
+      When operating TUF with DER metadata but checking the signature on some
+      piece of JSON for some reason, this should be manually set to 'json'. The
+      purpose of this canonicalization is to produce repeatable signatures
+      across different platforms and Python key dictionaries (avoiding things
+      like different signatures over the same dictionary).
+
+      If 'der', the data will be converted into ASN.1, encoded as DER,
+      and hashed. The signature is then checked against that hash.
+  """
+
+  tuf.formats.ANYKEY_SCHEMA.check_match(key_dict)
+  # TODO: Check format of data, based on metadata_format.
+  # TODO: Consider checking metadata_format redundantly. It's checked below.
+
+  if metadata_format == 'json':
+    data = tuf.formats.encode_canonical(data).encode('utf-8')
+
+  elif metadata_format == 'der':
+
+    # TODO: Have convert_signed_metadata_to_der take just the 'signed' element
+    # so we don't have to do this silly wrapping in an empty signable.
+    data = asn1_codec.convert_signed_metadata_to_der(
+        {'signed': data, 'signatures': []}, only_signed=True, datatype=datatype)
+    data = hashlib.sha256(data).digest()
+
+  else:
+    raise tuf.Error('Unsupported metadata format: ' + repr(metadata_format))
+
+
+  return tuf.keys.create_signature(key_dict, data)
+
+
+
+
+
+def verify_signature_over_metadata(
+    key_dict, signature, data, datatype,
+    metadata_format=tuf.conf.METADATA_FORMAT):
+  """
+  Almost exactly identical to the function simultaneously added to TUF,
+  tuf.sig.verify_signature_over_metadata(). Requires datatype.
+  Must differ in Uptane simply because it is not possible to convert
+  Uptane-specific metadata (Time Attestations, ECU Manifests, and Vehicle
+  Manifests) to or from ASN.1/DER without knowing which of those three
+  types of metadata you're dealign with, and this conversion is required for
+  signing and verifying signatures.
+
+  Higher level function that wraps tuf.keys.verify_signature, and works
+  specifically with Time Attestations, ECU Manifsts, and Vehicle Manifests that
+  will be in JSON or ASN.1/DER format.
+
+  See tuf.keys.verify_signature for overall functionality and the arguments
+  key_dict, signature, and data.
+
+  Optional argument:
+
+    metadata_format: (optional; default based on tuf.conf.METADATA_FORMAT)
+
+      If 'json', treats data as a JSON-friendly Python dictionary to be turned
+      into a canonical JSON string and then encoded as utf-8 before checking
+      against the signature. When operating TUF with DER metadata but checking
+      the signature on some piece of JSON for some reason, this should be
+      manually set to 'json'. The purpose of this canonicalization is to
+      produce repeatable signatures across different platforms and Python key
+      dictionaries (avoiding things like different signatures over the same
+      dictionary).
+
+      If 'der', the data will be converted into ASN.1, encoded as DER,
+      and hashed. The signature is then checked against that hash.
+  """
+
+  tuf.formats.ANYKEY_SCHEMA.check_match(key_dict)
+  tuf.formats.SIGNATURE_SCHEMA.check_match(signature)
+  # TODO: Check format of data, based on metadata_format.
+  # TODO: Consider checking metadata_format redundantly. It's checked below.
+
+  if metadata_format == 'json':
+    data = tuf.formats.encode_canonical(data).encode('utf-8')
+
+  elif metadata_format == 'der':
+
+    # TODO: Have convert_signed_metadata_to_der take just the 'signed' element
+    # so we don't have to do this silly wrapping in an empty signable.
+    data = asn1_codec.convert_signed_metadata_to_der(
+        {'signed': data, 'signatures': []}, only_signed=True, datatype=datatype)
+    data = hashlib.sha256(data).digest()
+
+  else:
+    raise tuf.Error('Unsupported metadata format: ' + repr(metadata_format))
+
+
+  return tuf.keys.verify_signature(key_dict, signature, data)
+
 
 
 

--- a/uptane/common.py
+++ b/uptane/common.py
@@ -116,10 +116,7 @@ def sign_signable(
         signing_key, signable['signed'], datatype=datatype,
         metadata_format=metadata_format))
 
-
   uptane.formats.ANY_SIGNABLE_UPTANE_METADATA_SCHEMA.check_match(signable)
-
-  return
 
 
 

--- a/uptane/encoding/asn1_codec.py
+++ b/uptane/encoding/asn1_codec.py
@@ -347,8 +347,7 @@ def convert_signed_metadata_to_der(
     # Tell keys.create_signature that the data we're providing is not JSON so
     # that it doesn't try to canonicalize it (and wrap the hash in double
     # quotes).
-    pydict_signatures = [tuf.keys.create_signature(
-        private_key, hash_of_der, force_non_json=True, is_binary_data=True)]
+    pydict_signatures = [tuf.keys.create_signature(private_key, hash_of_der)]
 
   else:
     pydict_signatures = signed_metadata['signatures']

--- a/uptane/services/director.py
+++ b/uptane/services/director.py
@@ -391,16 +391,18 @@ class Director:
       data_to_check = asn1_codec.convert_signed_metadata_to_der(
           vehicle_manifest, only_signed=True, datatype='vehicle_manifest')
       data_to_check = hashlib.sha256(data_to_check).digest()
+      is_binary_data = True
 
     else:
       data_to_check = vehicle_manifest['signed']
+      is_binary_data = False
 
 
     valid = tuf.keys.verify_signature(
         ecu_public_key,
         vehicle_manifest['signatures'][0], # TODO: Fix assumptions.
         data_to_check,
-        is_binary_data=True)
+        is_binary_data=is_binary_data)
 
     if not valid:
       log.debug(

--- a/uptane/services/director.py
+++ b/uptane/services/director.py
@@ -203,15 +203,17 @@ class Director:
       data_to_check = asn1_codec.convert_signed_metadata_to_der(
           signed_ecu_manifest, only_signed=True, datatype='ecu_manifest')
       data_to_check = hashlib.sha256(data_to_check).digest()
+      is_binary_data = True
 
     else:
       data_to_check = signed_ecu_manifest['signed']
+      is_binary_data = False
 
     valid = tuf.keys.verify_signature(
         ecu_public_key,
         signed_ecu_manifest['signatures'][0], # TODO: Fix assumptions.
         data_to_check,
-        is_binary_data=True)
+        is_binary_data=is_binary_data)
 
     if not valid:
       log.info(

--- a/uptane/services/timeserver.py
+++ b/uptane/services/timeserver.py
@@ -67,8 +67,11 @@ def get_signed_time(nonces):
   uptane.formats.SIGNABLE_TIMESERVER_ATTESTATION_SCHEMA.check_match(
       signable_time_attestation)
 
-  signable_time_attestation = uptane.common.sign_signable(
-      signable_time_attestation, [timeserver_key])
+  uptane.common.sign_signable(
+      signable_time_attestation,
+      [timeserver_key],
+      datatype='time_attestation',
+      metadata_format='json')
 
   return signable_time_attestation
 


### PR DESCRIPTION
Separate low-level signing code from encoding and formatting code once and for all. (:

This makes the code more readable and less confusing, and will hopefully saving a good bit of encoding debugging time....

[This TUF fork PR](https://github.com/awwad/tuf/pull/5) should be applied in tandem (so the build may fail, since it won't do that).