### PR TITLE
pyasn1 tagFormatSimple vs tagFormatConstructed

### DIFF
--- a/uptane/encoding/asn1_definitions.py
+++ b/uptane/encoding/asn1_definitions.py
@@ -589,7 +589,7 @@ VehicleVersionManifestSigned.componentType = namedtype.NamedTypes(
     namedtype.NamedType('vehicleIdentifier', Identifier().subtype(implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 0))),
     namedtype.NamedType('primaryIdentifier', Identifier().subtype(implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 1))),
     namedtype.NamedType('numberOfECUVersionManifests', Length().subtype(implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 2))),
-    namedtype.NamedType('ecuVersionManifests', ECUVersionManifests().subtype(implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 3))),
+    namedtype.NamedType('ecuVersionManifests', ECUVersionManifests().subtype(implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 3))), # Should this be tagFormatConstructed?
     namedtype.OptionalNamedType('securityAttack', char.VisibleString().subtype(subtypeSpec=constraint.ValueSizeConstraint(1, 1024)).subtype(implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 4)))
 )
 

--- a/uptane/encoding/vehicle_manifest_asn1_coder.py
+++ b/uptane/encoding/vehicle_manifest_asn1_coder.py
@@ -33,7 +33,7 @@ def get_asn_signed(json_signed):
 
   ecuVersionManifests = ECUVersionManifests()\
                         .subtype(implicitTag=tag.Tag(tag.tagClassContext,
-                                                     tag.tagFormatSimple, 3))
+                                                     tag.tagFormatSimple, 3)) # Should this be tagFormatConstructed?
   numberOfECUVersionManifests = 0
 
   # We're going to generate a list of ECU Manifests from the dictionary of lists


### PR DESCRIPTION
Reorders some imports, removes some unused code, clarifies a docstring in response to a @vladimir-v-diaz comment on PR #71, makes values easier to change in `demo/__init__.py`.