### PR TITLE
Work around pip git-based reinstall issue by specifying TUF branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,17 @@ $ pip install -r dev-requirements.txt
 ```
 
 #### Updates
-When updating Uptane code, please reinstall its dependencies, as the corresponding TUF fork may be updated: `pip install --force-reinstall -r dev-requirements.txt`
+When updating Uptane code, please reinstall its dependencies, as the
+corresponding TUF fork may be updated:
+`pip install --force-reinstall -r dev-requirements.txt`
 
 #### Metadata format
-Note that the demonstration now operates using ASN.1 / DER format and encoding for metadata files by default. This can be switched back to JSON (which is human readable) by changing the tuf.conf.METADATA_FORMAT option in `uptane/__init__.py`.
+Note that the demonstration now operates using ASN.1 / DER format and encoding
+for metadata files by default. If desired, this can be switched to JSON (which
+results in human-readable metadata files) by changing the
+tuf.conf.METADATA_FORMAT option in `uptane/__init__.py`, from 'der' to 'json'
+`tuf.conf.METADATA_FORMAT = 'json'`
+
 
 #### Install command-line audio player (optional)
 If you want the demo to play notification sounds you need one of the following audio player command line utilities on your path:

--- a/README.md
+++ b/README.md
@@ -51,14 +51,18 @@ $ cd uptane
 $ pip install -r dev-requirements.txt
 ```
 
-Note that the demonstration now operates using ASN.1 / DER format and encoding for metadata files by default. The TUF branch in use has been switched accordingly (so please run the command above again if you have an existing installation). This can be switched back to JSON (which is human readable) by changing the tuf.conf.METADATA_FORMAT option in uptane/\_\_init\_\_.py.
+#### Updates
+When updating Uptane code, please reinstall its dependencies, as the corresponding TUF fork may be updated: `pip install --force-reinstall -r dev-requirements.txt`
 
+#### Metadata format
+Note that the demonstration now operates using ASN.1 / DER format and encoding for metadata files by default. This can be switched back to JSON (which is human readable) by changing the tuf.conf.METADATA_FORMAT option in `uptane/__init__.py`.
 
-### Install command-line audio player (optional)
+#### Install command-line audio player (optional)
 If you want the demo to play notification sounds you need one of the following audio player command line utilities on your path:
 - mplayer (available for all major operating systems)
 - omxplayer (built-in on Raspbian)
 - afplay (built-in on OS X)
+
 
 # 1: Starting the Demo
 The code below is intended to be run in five or more consoles:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,6 +4,6 @@ cryptography==1.7.2
 pynacl==1.0.1
 pyasn1==0.2.2
 pycrypto==2.6.1
---editable git://github.com/awwad/tuf.git#egg=tuf
+--editable git://github.com/awwad/tuf.git@develop#egg=tuf
 --editable .
 tox==2.6.0


### PR DESCRIPTION
and instruct users to run the reinstall command when updating Uptane, so as to avoid TUF version incompatibility.

We'll use 
`pip install --force-reinstall -r dev-requirements.txt`

and in dev-requirements, we'll specify the develop branch.

See [this issue](https://github.com/pypa/pip/issues/4448) in pip.