### PR TITLE
Correctly handle key revocation for demo Image Repo

### DIFF
--- a/demo/demo_director.py
+++ b/demo/demo_director.py
@@ -343,21 +343,18 @@ def revoke_compromised_keys():
   new_targets_public_key = demo.import_public_key(new_targets_keyname)
   new_targets_private_key = demo.import_private_key(new_targets_keyname)
   old_targets_public_key = director_service_instance.key_dirtarg_pub
-  old_targets_private_key = director_service_instance.key_dirtarg_pri
 
   # Timestamp...
   demo.generate_key(new_timestamp_keyname)
   new_timestamp_public_key = demo.import_public_key(new_timestamp_keyname)
   new_timestamp_private_key = demo.import_private_key(new_timestamp_keyname)
   old_timestamp_public_key = director_service_instance.key_dirtime_pub
-  old_timestamp_private_key = director_service_instance.key_dirtime_pri
 
   # And Snapshot.
   demo.generate_key(new_snapshot_keyname)
   new_snapshot_public_key = demo.import_public_key(new_snapshot_keyname)
   new_snapshot_private_key = demo.import_private_key(new_snapshot_keyname)
   old_snapshot_public_key = director_service_instance.key_dirsnap_pub
-  old_snapshot_private_key = director_service_instance.key_dirsnap_pri
 
   # Set the new public and private Targets keys in the director service.
   # These keys are shared between all vehicle repositories.
@@ -383,10 +380,11 @@ def revoke_compromised_keys():
     repository.snapshot.add_verification_key(new_snapshot_public_key)
 
     # Unload the old signing keys so that the new metadata only contains
-    # signatures produced by the new signing keys.
-    repository.targets.unload_signing_key(old_targets_private_key)
-    repository.snapshot.unload_signing_key(old_snapshot_private_key)
-    repository.timestamp.unload_signing_key(old_timestamp_private_key)
+    # signatures produced by the new signing keys. Since this is based on
+    # keyid, the public key can be used.
+    repository.targets.unload_signing_key(old_targets_public_key)
+    repository.snapshot.unload_signing_key(old_snapshot_public_key)
+    repository.timestamp.unload_signing_key(old_timestamp_public_key)
 
     # Load the new signing keys to write metadata. The root key is unchanged,
     # and in the demo it is already loaded.

--- a/demo/demo_image_repo.py
+++ b/demo/demo_image_repo.py
@@ -438,8 +438,8 @@ def revoke_compromised_keys():
   repo.snapshot.load_signing_key(new_snapshot_private_key)
   repo.timestamp.load_signing_key(new_timestamp_private_key)
 
-  # Write all the metadata changes to disk (metadata.staging) and copy move
-  # them to the hosted metadata directory.
+  # Write all the metadata changes to disk (metadata.staged) and copy them to
+  # the hosted metadata directory.
   write_to_live()
 
 

--- a/demo/demo_image_repo.py
+++ b/demo/demo_image_repo.py
@@ -421,14 +421,26 @@ def revoke_compromised_keys():
   repo.snapshot.add_verification_key(new_snapshot_public_key)
 
   # Load the new signing keys to write metadata. The root key is unchanged,
-  # and in the demo it is already loaded.
+  # and in the demo it is already loaded. Since we only need the keyid,
+  # public keys can be used here.
+  repo.targets.unload_signing_key(old_targets_public_key)
+  repo.snapshot.unload_signing_key(old_snapshot_public_key)
+  repo.timestamp.unload_signing_key(old_timestamp_public_key)
+
+  # Make sure that the root metadata is written on the next repository write,
+  # in addition to the other metadata. This should probably happen
+  # automatically.
+  # TODO: After the TUF fork merges, see if root is automatically marked dirty
+  # when the signing keys for top-level roles are reassigned.
+  repo.mark_dirty(['root'])
+
   repo.targets.load_signing_key(new_targets_private_key)
   repo.snapshot.load_signing_key(new_snapshot_private_key)
   repo.timestamp.load_signing_key(new_timestamp_private_key)
 
-  # Write all the metadata changes to disk.  Note: write() will be writeall()
-  # in the latest version of the TUF codebase.
-  repo.write()
+  # Write all the metadata changes to disk (metadata.staging) and copy move
+  # them to the hosted metadata directory.
+  write_to_live()
 
 
 


### PR DESCRIPTION
A few corrections were missed that do not impact the demo attacks as currently written (813daff).

Also, we can avoid using a variable to refer to the old private keys in the demo Director revocation function and thereby reduce clutter a bit.
