### PR TITLE
Web frontend attack support

### DIFF
--- a/demo/demo_director.py
+++ b/demo/demo_director.py
@@ -403,6 +403,8 @@ def revoke_compromised_keys():
 
 
 
+
+
 def sign_with_compromised_keys_attack():
   """
   <Purpose>
@@ -428,6 +430,8 @@ def sign_with_compromised_keys_attack():
   """
 
   global director_service_instance
+
+  print('ATTACK: arbitrary metadata, old key, all vehicles')
 
   # Start by backing up the repository before the attack occurs so that we
   # can restore it afterwards in undo_sign_with_compromised_keys_attack.
@@ -486,6 +490,10 @@ def sign_with_compromised_keys_attack():
     os.rename(os.path.join(repo_dir, 'metadata.livetemp'),
         os.path.join(repo_dir, 'metadata'))
 
+  print('COMPLETED ATTACK')
+
+
+
 
 
 def undo_sign_with_compromised_keys_attack():
@@ -539,6 +547,8 @@ def undo_sign_with_compromised_keys_attack():
     repository.targets.load_signing_key(valid_targets_private_key)
     repository.snapshot.load_signing_key(valid_snapshot_private_key)
     repository.timestamp.load_signing_key(valid_timestamp_private_key)
+
+  print('COMPLETED UNDO ATTACK')
 
 
 
@@ -788,6 +798,9 @@ def mitm_arbitrary_package_attack(vin, target_filepath):
   compromising any keys.  Move an evil target file into place on the Director
   repository without updating metadata.
   """
+  print('ATTACK: arbitrary package, no keys, on VIN ' + repr(vin) + ', '
+      'target_filepath ' + repr(target_filepath))
+
   full_target_filepath = os.path.join(demo.DIRECTOR_REPO_DIR, vin,
       'targets', target_filepath)
 
@@ -827,6 +840,8 @@ def mitm_arbitrary_package_attack(vin, target_filepath):
     file_object.write('EVIL UPDATE: ARBITRARY PACKAGE ATTACK TO BE'
         ' DELIVERED FROM MITM (no keys compromised).')
 
+  print('COMPLETED ATTACK')
+
 
 
 
@@ -837,6 +852,9 @@ def undo_mitm_arbitrary_package_attack(vin, target_filepath):
   mitm_arbitrary_package_attack().  Move evil target file out and normal
   target file back in.
   """
+  print('UNDO ATTACK: arbitrary package, no keys, on VIN ' + repr(vin) + ', '
+      'target_filepath ' + repr(target_filepath))
+
   full_target_filepath = os.path.join(demo.DIRECTOR_REPO_DIR, vin,
       'targets', target_filepath)
 
@@ -868,6 +886,7 @@ def undo_mitm_arbitrary_package_attack(vin, target_filepath):
   elif os.path.exists(image_repo_backup_full_target_filepath):
     os.remove(image_repo_backup_full_target_filepath)
 
+  print('COMPLETED UNDO ATTACK')
 
 
 
@@ -983,9 +1002,12 @@ def prepare_replay_attack_nokeys(vin):
   version of the timestamp data. Then, replay_attack_nokeys() should be run to
   actually perform the attack.
   """
+  print('PREPARE ATTACK: replay attack, no keys, on VIN ' + repr(vin))
+
   backup_timestamp(vin=vin)
   write_to_live(vin_to_update=vin)
 
+  print('COMPLETED ATTACK PREPARATION')
 
 
 
@@ -999,7 +1021,11 @@ def replay_attack_nokeys(vin):
   prepare_replay_attack_nokeys should be called first, and then the Primary
   should have updated before this is called.
   """
+  print('ATTACK: replay attack, no keys, on VIN ' + repr(vin))
+
   replay_timestamp(vin=vin)
+
+  print('COMPLETED ATTACK')
 
 
 
@@ -1012,7 +1038,11 @@ def undo_replay_attack_nokeys(vin):
 
   This attack is attack described in README.md, section 3.3.
   """
+  print('UNDO ATTACK: replay attack, no keys, on VIN ' + repr(vin))
+
   restore_timestamp(vin=vin)
+
+  print('COMPLETED UNDO ATTACK')
 
 
 
@@ -1026,9 +1056,13 @@ def keyed_arbitrary_package_attack(vin, ecu_serial, target_filepath):
 
   This attack is described in README.md, section 3.4.
   """
+  print('ATTACK: keyed_arbitrary_package_attack with parameters '
+      ': vin ' + repr(vin) + '; ecu_serial ' + repr(ecu_serial) + '; '
+      'target_filepath ' + repr(target_filepath))
 
   # TODO: Back up the image first.
   if not os.path.exists(target_filepath):
+
     raise uptane.Error('Unable to attack: expected given image filename, ' +
         repr(target_filepath) + ', to exist, but it does not.')
 
@@ -1040,6 +1074,8 @@ def keyed_arbitrary_package_attack(vin, ecu_serial, target_filepath):
   add_target_and_write_to_live(
       target_filepath, file_content='evil content',
       vin=vin, ecu_serial=ecu_serial)
+
+  print('COMPLETED ATTACK')
 
 
 
@@ -1058,12 +1094,18 @@ def undo_keyed_arbitrary_package_attack(vin, ecu_serial, target_filepath):
   This attack recovery is described in README.md, section 3.6.
   """
 
+  print('UNDO ATACK: keyed arbitrary package attack with parameters '
+      ': vin ' + repr(vin) + '; ecu_serial ' + repr(ecu_serial) + '; '
+      'target_filepath ' + repr(target_filepath))
+
   # Revoke potentially compromised keys, replacing them with new keys.
   revoke_compromised_keys()
 
   # Replace malicious target with original.
   dd.add_target_and_write_to_live(filename=target_filepath,
       file_content='Fresh firmware image', vin=vin, ecu_serial=ecu_serial)
+
+  print('COMPLETED UNDO ATTACK')
 
 
 
@@ -1083,6 +1125,7 @@ def clear_vehicle_targets(vin):
   TODO: In the future, adding a target assignment to the Director for a given
   ECU should replace any other target assignment for that ECU.
   """
+  print('CLEARING VEHICLE TARGETS for VIN ' + repr(vin))
   director_service_instance.vehicle_repositories[vin].targets.clear_targets()
 
 

--- a/demo/demo_director.py
+++ b/demo/demo_director.py
@@ -781,10 +781,13 @@ def listen():
 
 
 
+
 def mitm_arbitrary_package_attack(vin, target_filepath):
-  # Simulate an arbitrary package attack by a Man in the Middle, without
-  # compromising any keys.  Move an evil target file into place on the Director
-  # repository without updating metadata.
+  """
+  Simulate an arbitrary package attack by a Man in the Middle, without
+  compromising any keys.  Move an evil target file into place on the Director
+  repository without updating metadata.
+  """
   full_target_filepath = os.path.join(demo.DIRECTOR_REPO_DIR, vin,
       'targets', target_filepath)
 
@@ -829,9 +832,11 @@ def mitm_arbitrary_package_attack(vin, target_filepath):
 
 
 def undo_mitm_arbitrary_package_attack(vin, target_filepath):
-  # Undo the arbitrary package attack launched by
-  # mitm_arbitrary_package_attack().  Move evil target file out and normal
-  # target file back in.
+  """
+  Undo the arbitrary package attack launched by
+  mitm_arbitrary_package_attack().  Move evil target file out and normal
+  target file back in.
+  """
   full_target_filepath = os.path.join(demo.DIRECTOR_REPO_DIR, vin,
       'targets', target_filepath)
 

--- a/demo/demo_director.py
+++ b/demo/demo_director.py
@@ -863,7 +863,7 @@ def undo_mitm_arbitrary_package_attack(vin, target_filepath):
 
 
 """
-Simulating a rollback attack can be done with instructions in README.md,
+Simulating a replay attack can be done with instructions in README.md,
 using the functions below.
 """
 
@@ -890,7 +890,7 @@ def backup_timestamp(vin):
 
 
 
-def rollback_timestamp(vin):
+def replay_timestamp(vin):
   """
   Move 'backup_timestamp.der' to 'timestamp.der', effectively rolling back
   timestamp to a previous version.  'backup_timestamp.der' must already exist
@@ -902,7 +902,7 @@ def rollback_timestamp(vin):
   >>> import demo.demo_director as dd
   >>> dd.clean_slate()
   >>> dd.backup_timestamp('111')
-  >>> dd.rollback_timestamp()
+  >>> dd.replay_timestamp()
   """
 
   timestamp_filename = 'timestamp.' + tuf.conf.METADATA_FORMAT
@@ -910,7 +910,7 @@ def rollback_timestamp(vin):
       'backup_' + timestamp_filename)
 
   if not os.path.exists(backup_timestamp_path):
-    raise Exception('Cannot rollback the Timestamp'
+    raise Exception('Cannot replay the Timestamp'
         ' file.  ' + repr(backup_timestamp_path) + ' must already exist.'
         '  It can be created by calling backup_timestamp(vin).')
 
@@ -937,7 +937,7 @@ def restore_timestamp(vin):
   >>> import demo.demo_director as dd
   >>> dd.clean_slate()
   >>> dd.backup_timestamp('111')
-  >>> dd.rollback_timestamp()
+  >>> dd.replay_timestamp()
   >>> dd.restore_timestamp()
   """
 

--- a/demo/demo_director.py
+++ b/demo/demo_director.py
@@ -742,26 +742,31 @@ def listen():
 
   server.register_function(clear_vehicle_targets, 'clear_vehicle_targets')
 
-  # Attack 1: Arbitrary Package, no keys
+  # Attack 1: Arbitrary Package Attack on Director Repository without
+  # Compromised Keys.
+  # README.md section 3.1
   server.register_function(mitm_arbitrary_package_attack,
       'mitm_arbitrary_package_attack')
   server.register_function(undo_mitm_arbitrary_package_attack,
       'undo_mitm_arbitrary_package_attack')
 
-  # Attack 2: Replay, no keys
+  # Attack 2: Replay Attack without Compromised Keys
+  # README.md section 3.3
   server.register_function(prepare_replay_attack_nokeys,
       'prepare_replay_attack_nokeys')
   server.register_function(replay_attack_nokeys, 'replay_attack_nokeys')
   server.register_function(undo_replay_attack_nokeys,
       'undo_replay_attack_nokeys')
 
-  # Attack 3: Arbitrary Package, keyed
+  # Attack 3: Arbitrary Package Attack with a Compromised Director Key
+  # README.md section 3.4. Recovery in section 3.6
   server.register_function(keyed_arbitrary_package_attack,
       'keyed_arbitrary_package_attack')
   server.register_function(undo_keyed_arbitrary_package_attack,
       'undo_keyed_arbitrary_package_attack')
 
-  # Attack 4: Arbitrary Package, Revoked Key
+  # Attack 4: Arbitrary Package with Revoked Keys
+  # (README.md section 3.7)
   server.register_function(sign_with_compromised_keys_attack,
       'sign_with_compromised_keys_attack')
   server.register_function(undo_sign_with_compromised_keys_attack,

--- a/demo/demo_director.py
+++ b/demo/demo_director.py
@@ -936,6 +936,70 @@ def restore_timestamp(vin):
 
 
 
+def prepare_replay_attack_nokeys(vin):
+  """
+  For exposure via XMLRPC to web frontend, attack script to prepare to execute a
+  rollback attack with no compromised keys against the Director.
+
+  After this is done, the Primary should update, then the replay attack function
+  should be run (replay_attack_nokeys).
+  """
+  backup_timestamp(vin=vin)
+  write_to_live(vin_to_update=vin)
+
+
+
+
+
+def replay_attack_nokeys(vin):
+  """Actually perform the rollback attack."""
+  rollback_timestamp(vin=vin)
+
+
+
+
+
+def undo_replay_attack_nokeys(vin):
+  """Undo the rollback attack."""
+  restore_timestamp(vin=vin)
+
+
+
+
+
+def keyed_arbitrary_package_attack(vin, ecu_serial, target_filepath):
+
+  # TODO: Back up the image first.
+  if not os.path.exists(target_filepath):
+    raise uptane.Error('Unable to attack: expected given image filename, ' +
+        repr(target_filepath) + ', to exist, but it does not.')
+
+  # TODO: Check to make sure the given file exists in the repository as well.
+  # We should be attacking a file that's already in the repo.
+  # TODO: Consider adding other edge case checks (interrupted things, attack
+  # already in progress, etc.)
+
+  add_target_and_write_to_live(
+      target_filepath, file_content='evil content',
+      vin=vin, ecu_serial=ecu_serial)
+
+
+
+
+
+def undo_keyed_arbitrary_package_attack(vin, ecu_serial, target_filepath):
+
+  # Revoke potentially compromised keys, replacing them with new keys.
+  revoke_and_add_new_keys_and_write_to_live()
+
+  # Replace malicious target with original.
+  dd.add_target_and_write_to_live(filename=target_filepath,
+      file_content='Fresh firmware image', vin=vin, ecu_serial=ecu_serial)
+
+
+
+
+
 def clear_vehicle_targets(vin):
   director_service_instance.vehicle_repositories[vin].targets.clear_targets()
 

--- a/demo/demo_director.py
+++ b/demo/demo_director.py
@@ -1060,9 +1060,19 @@ def keyed_arbitrary_package_attack(vin, ecu_serial, target_filepath):
       ': vin ' + repr(vin) + '; ecu_serial ' + repr(ecu_serial) + '; '
       'target_filepath ' + repr(target_filepath))
 
-  # TODO: Back up the image first.
-  if not os.path.exists(target_filepath):
 
+  # TODO: Back up the image and then restore it in the undo function instead of
+  # hard-coding the contents it's changed back to in the undo function.
+  # That would require that we pick a temp file location.
+
+  # Determine the location the specified file would occupy in the repository.
+  target_full_path = os.path.join(
+      director_service_instance.vehicle_repositories[vin]._repository_directory,
+      'targets', target_filepath)
+
+  # Make sure it exists in the repository, or else abort this attack, which is
+  # written to work on an existing target only.
+  if not os.path.exists(target_full_path):
     raise uptane.Error('Unable to attack: expected given image filename, ' +
         repr(target_filepath) + ', to exist, but it does not.')
 
@@ -1071,6 +1081,7 @@ def keyed_arbitrary_package_attack(vin, ecu_serial, target_filepath):
   # TODO: Consider adding other edge case checks (interrupted things, attack
   # already in progress, etc.)
 
+  # Replace the given target with a malicious version.
   add_target_and_write_to_live(
       target_filepath, file_content='evil content',
       vin=vin, ecu_serial=ecu_serial)

--- a/demo/demo_director.py
+++ b/demo/demo_director.py
@@ -1012,7 +1012,7 @@ def keyed_arbitrary_package_attack(vin, ecu_serial, target_filepath):
 def undo_keyed_arbitrary_package_attack(vin, ecu_serial, target_filepath):
 
   # Revoke potentially compromised keys, replacing them with new keys.
-  revoke_and_add_new_keys_and_write_to_live()
+  revoke_compromised_keys()
 
   # Replace malicious target with original.
   dd.add_target_and_write_to_live(filename=target_filepath,

--- a/demo/demo_director.py
+++ b/demo/demo_director.py
@@ -617,7 +617,7 @@ def host():
   global repo_server_process
 
   if repo_server_process is not None:
-    print('Sorry, there is already a server process running.')
+    print('Sorry: there is already a server process running.')
     return
 
   # Prepare to host the director repo contents.
@@ -699,7 +699,7 @@ def listen():
   global director_service_thread
 
   if director_service_thread is not None:
-    print('Sorry - there is already a Director service thread listening.')
+    print('Sorry: there is already a Director service thread listening.')
     return
 
   # Create server

--- a/demo/demo_director.py
+++ b/demo/demo_director.py
@@ -1105,7 +1105,7 @@ def undo_keyed_arbitrary_package_attack(vin, ecu_serial, target_filepath):
   This attack recovery is described in README.md, section 3.6.
   """
 
-  print('UNDO ATACK: keyed arbitrary package attack with parameters '
+  print('UNDO ATTACK: keyed arbitrary package attack with parameters '
       ': vin ' + repr(vin) + '; ecu_serial ' + repr(ecu_serial) + '; '
       'target_filepath ' + repr(target_filepath))
 
@@ -1113,7 +1113,7 @@ def undo_keyed_arbitrary_package_attack(vin, ecu_serial, target_filepath):
   revoke_compromised_keys()
 
   # Replace malicious target with original.
-  dd.add_target_and_write_to_live(filename=target_filepath,
+  add_target_and_write_to_live(filename=target_filepath,
       file_content='Fresh firmware image', vin=vin, ecu_serial=ecu_serial)
 
   print('COMPLETED UNDO ATTACK')

--- a/demo/demo_director.py
+++ b/demo/demo_director.py
@@ -966,7 +966,7 @@ def restore_timestamp(vin):
 def prepare_replay_attack_nokeys(vin):
   """
   For exposure via XMLRPC to web frontend, attack script to prepare to execute a
-  rollback attack with no compromised keys against the Director.
+  replay attack with no compromised keys against the Director.
   This attack is described in README.md, section 3.3.
 
   1. Back up the existing, soon-to-be-outdated timestamp file, so that it can
@@ -987,14 +987,14 @@ def prepare_replay_attack_nokeys(vin):
 
 def replay_attack_nokeys(vin):
   """
-  Actually perform the rollback attack.
+  Actually perform the replay attack.
 
   This attack is described in README.md, section 3.3.
 
   prepare_replay_attack_nokeys should be called first, and then the Primary
   should have updated before this is called.
   """
-  rollback_timestamp(vin=vin)
+  replay_timestamp(vin=vin)
 
 
 

--- a/demo/demo_director.py
+++ b/demo/demo_director.py
@@ -742,8 +742,30 @@ def listen():
 
   server.register_function(clear_vehicle_targets, 'clear_vehicle_targets')
 
-  server.register_function(mitm_arbitrary_package_attack, 'mitm_arbitrary_package_attack')
-  server.register_function(undo_mitm_arbitrary_package_attack, 'undo_mitm_arbitrary_package_attack')
+  # Attack 1: Arbitrary Package, no keys
+  server.register_function(mitm_arbitrary_package_attack,
+      'mitm_arbitrary_package_attack')
+  server.register_function(undo_mitm_arbitrary_package_attack,
+      'undo_mitm_arbitrary_package_attack')
+
+  # Attack 2: Replay, no keys
+  server.register_function(prepare_replay_attack_nokeys,
+      'prepare_replay_attack_nokeys')
+  server.register_function(replay_attack_nokeys, 'replay_attack_nokeys')
+  server.register_function(undo_replay_attack_nokeys,
+      'undo_replay_attack_nokeys')
+
+  # Attack 3: Arbitrary Package, keyed
+  server.register_function(keyed_arbitrary_package_attack,
+      'keyed_arbitrary_package_attack')
+  server.register_function(undo_keyed_arbitrary_package_attack,
+      'undo_keyed_arbitrary_package_attack')
+
+  # Attack 4: Arbitrary Package, Revoked Key
+  server.register_function(sign_with_compromised_keys_attack,
+      'sign_with_compromised_keys_attack')
+  server.register_function(undo_sign_with_compromised_keys_attack,
+      'undo_sign_with_compromised_keys_attack')
 
   print('Starting Director Services Thread: will now listen on port ' +
       str(demo.DIRECTOR_SERVER_PORT))

--- a/demo/demo_image_repo.py
+++ b/demo/demo_image_repo.py
@@ -186,7 +186,7 @@ def host():
   global server_process
 
   if server_process is not None:
-    print('Sorry, there is already a server process running.')
+    print('Sorry: there is already a server process running.')
     return
 
   # Prepare to host the main repo contents

--- a/demo/demo_image_repo.py
+++ b/demo/demo_image_repo.py
@@ -387,7 +387,7 @@ def keyed_arbitrary_package_attack(target_filepath):
 
 def undo_keyed_arbitrary_package_attack(target_filepath):
   # Revoke potentially compromised keys, replacing them with new keys.
-  revoke_and_add_new_keys_and_write_to_live()
+  revoke_compromised_keys()
 
   # Replace malicious target with original.
   dd.add_target_and_write_to_live(filename=target_filepath,

--- a/demo/demo_image_repo.py
+++ b/demo/demo_image_repo.py
@@ -267,27 +267,34 @@ def listen():
       'add_target_to_supplier_repo')
   server.register_function(write_to_live, 'write_supplier_repo')
 
-  # Attack 1: Arbitrary Package, no keys
+  # Attack 1: Arbitrary Package Attack on Image Repository without
+  # Compromised Keys.
+  # README.md section 3.2
   server.register_function(mitm_arbitrary_package_attack,
       'mitm_arbitrary_package_attack')
   server.register_function(undo_mitm_arbitrary_package_attack,
       'undo_mitm_arbitrary_package_attack')
 
-  # Attack 2:
+  # Attack 2: Replay Attack without Compromised Keys
   # We don't bother performing the replay attack against the Image Repo;
   # demonstration on the Director Repo is enough.
 
-  # Attack 3: Arbitrary Package, keyed
+  # Attack 3: Arbitrary Package Attack with Compromised Image Repository Keys
+  # README.md section 3.5. Recovery in section 3.6
   server.register_function(keyed_arbitrary_package_attack,
       'keyed_arbitrary_package_attack')
   server.register_function(undo_keyed_arbitrary_package_attack,
       'undo_keyed_arbitrary_package_attack')
 
-  # Attack 4: Arbitrary Package, Revoked Key
+  # Attack 4: Arbitrary Package with Revoked Keys
+  # We don't bother performing this attack against the Image Repo;
+  # demonstration on the Director Repo should suffice. There is code linked
+  # here that should suffice, though.
   server.register_function(sign_with_compromised_keys_attack,
       'sign_with_compromised_keys_attack')
   server.register_function(undo_sign_with_compromised_keys_attack,
       'undo_sign_with_compromised_keys_attack')
+
 
   print('Starting Supplier Repo Services Thread: will now listen on port ' +
       str(demo.MAIN_REPO_SERVICE_PORT))

--- a/demo/demo_image_repo.py
+++ b/demo/demo_image_repo.py
@@ -346,6 +346,35 @@ def undo_mitm_arbitrary_package_attack(target_filepath):
 
 
 
+def keyed_arbitrary_package_attack(target_filepath):
+  # TODO: Back up the image first.
+  if not os.path.exists(target_filepath):
+    raise uptane.Error('Unable to attack: expected given image filename, ' +
+        repr(target_filepath) + ', to exist, but it does not.')
+
+  # TODO: Check to make sure the given file exists in the repository as well.
+  # We should be attacking a file that's already in the repo.
+  # TODO: Consider adding other edge case checks (interrupted things, attack
+  # already in progress, etc.)
+
+  add_target_and_write_to_live(target_filepath, file_content='evil content')
+
+
+
+
+
+def undo_keyed_arbitrary_package_attack(target_filepath):
+  # Revoke potentially compromised keys, replacing them with new keys.
+  revoke_and_add_new_keys_and_write_to_live()
+
+  # Replace malicious target with original.
+  dd.add_target_and_write_to_live(filename=target_filepath,
+      file_content='Fresh firmware image')
+
+
+
+
+
 def add_target_and_write_to_live(filename, file_content):
   """
   High-level version of add_target_to_imagerepo() that creates the target

--- a/demo/demo_image_repo.py
+++ b/demo/demo_image_repo.py
@@ -348,6 +348,9 @@ def undo_mitm_arbitrary_package_attack(target_filepath):
   mitm_arbitrary_package_attack().
   Move the evil target file out and normal target file back in.
   """
+  print('UNDO ATTACK: arbitrary package, no keys, on VIN ' + repr(vin) + ', '
+      'target_filepath ' + repr(target_filepath))
+
   full_target_filepath = os.path.join(demo.MAIN_REPO_TARGETS_DIR, target_filepath)
 
   # TODO: NOTE THAT THIS ATTACK SCRIPT BREAKS IF THE TARGET FILE IS IN A
@@ -364,6 +367,8 @@ def undo_mitm_arbitrary_package_attack(target_filepath):
   # so we restore the backup over it.
   os.rename(backup_target_filepath, full_target_filepath)
 
+  print('COMPLETED UNDO ATTACK')
+
 
 
 
@@ -378,6 +383,10 @@ def keyed_arbitrary_package_attack(target_filepath):
   """
   # TODO: Back up the image first.
   if not os.path.exists(target_filepath):
+  print('ATTACK: keyed_arbitrary_package_attack with parameters '
+      ': vin ' + repr(vin) + '; ecu_serial ' + repr(ecu_serial) + '; '
+      'target_filepath ' + repr(target_filepath))
+
     raise uptane.Error('Unable to attack: expected given image filename, ' +
         repr(target_filepath) + ', to exist, but it does not.')
 
@@ -387,6 +396,8 @@ def keyed_arbitrary_package_attack(target_filepath):
   # already in progress, etc.)
 
   add_target_and_write_to_live(target_filepath, file_content='evil content')
+
+  print('COMPLETED ATTACK')
 
 
 
@@ -404,12 +415,18 @@ def undo_keyed_arbitrary_package_attack(target_filepath):
 
   This attack recovery is described in README.md, section 3.6.
   """
+  print('UNDO ATACK: keyed arbitrary package attack with parameters '
+      ': vin ' + repr(vin) + '; ecu_serial ' + repr(ecu_serial) + '; '
+      'target_filepath ' + repr(target_filepath))
+
   # Revoke potentially compromised keys, replacing them with new keys.
   revoke_compromised_keys()
 
   # Replace malicious target with original.
   dd.add_target_and_write_to_live(filename=target_filepath,
       file_content='Fresh firmware image')
+
+  print('COMPLETED UNDO ATTACK')
 
 
 

--- a/demo/demo_image_repo.py
+++ b/demo/demo_image_repo.py
@@ -251,7 +251,7 @@ def listen():
   global xmlrpc_service_thread
 
   if xmlrpc_service_thread is not None:
-    print('Sorry - there is already a Director service thread listening.')
+    print('Sorry: there is already a listening Image Repository service thread')
     return
 
   # Create server

--- a/demo/demo_image_repo.py
+++ b/demo/demo_image_repo.py
@@ -343,8 +343,11 @@ def mitm_arbitrary_package_attack(target_filepath):
 
 
 def undo_mitm_arbitrary_package_attack(target_filepath):
-  # Undo the arbitrary package attack simulated by mitm_arbitrary_package_attack().
-  # Move the evil target file out and normal target file back in.
+  """
+  Undo the arbitrary package attack simulated by
+  mitm_arbitrary_package_attack().
+  Move the evil target file out and normal target file back in.
+  """
   full_target_filepath = os.path.join(demo.MAIN_REPO_TARGETS_DIR, target_filepath)
 
   # TODO: NOTE THAT THIS ATTACK SCRIPT BREAKS IF THE TARGET FILE IS IN A

--- a/demo/demo_image_repo.py
+++ b/demo/demo_image_repo.py
@@ -381,12 +381,22 @@ def keyed_arbitrary_package_attack(target_filepath):
 
   This attack is described in README.md, section 3.5.
   """
-  # TODO: Back up the image first.
-  if not os.path.exists(target_filepath):
   print('ATTACK: keyed_arbitrary_package_attack with parameters '
       ': vin ' + repr(vin) + '; ecu_serial ' + repr(ecu_serial) + '; '
       'target_filepath ' + repr(target_filepath))
 
+
+  # TODO: Back up the image and then restore it in the undo function instead of
+  # hard-coding the contents it's changed back to in the undo function.
+  # That would require that we pick a temp file location.
+
+  # Determine the location the specified file would occupy in the repository.
+  target_full_path = os.path.join(
+      repo._repository_directory, 'targets', target_filepath)
+
+  # Make sure it exists in the repository, or else abort this attack, which is
+  # written to work on an existing target only.
+  if not os.path.exists(target_full_path):
     raise uptane.Error('Unable to attack: expected given image filename, ' +
         repr(target_filepath) + ', to exist, but it does not.')
 
@@ -395,6 +405,7 @@ def keyed_arbitrary_package_attack(target_filepath):
   # TODO: Consider adding other edge case checks (interrupted things, attack
   # already in progress, etc.)
 
+  # Replace the given target with a malicious version.
   add_target_and_write_to_live(target_filepath, file_content='evil content')
 
   print('COMPLETED ATTACK')

--- a/demo/demo_image_repo.py
+++ b/demo/demo_image_repo.py
@@ -299,7 +299,7 @@ def mitm_arbitrary_package_attack(target_filepath):
   # Simulate an arbitrary package attack by a Man in the Middle, without
   # compromising keys.  Move evil target file into place on the image
   # repository, without updating metadata.
-  print('UNDO ATTACK: arbitrary package, no keys, on target ' +
+  print('ATTACK: arbitrary package, no keys, on target ' +
       repr(target_filepath))
 
   full_target_filepath = os.path.join(demo.MAIN_REPO_TARGETS_DIR, target_filepath)

--- a/demo/demo_image_repo.py
+++ b/demo/demo_image_repo.py
@@ -286,16 +286,6 @@ def listen():
   server.register_function(undo_keyed_arbitrary_package_attack,
       'undo_keyed_arbitrary_package_attack')
 
-  # Attack 4: Arbitrary Package with Revoked Keys
-  # We don't bother performing this attack against the Image Repo;
-  # demonstration on the Director Repo should suffice. There is code linked
-  # here that should suffice, though.
-  server.register_function(sign_with_compromised_keys_attack,
-      'sign_with_compromised_keys_attack')
-  server.register_function(undo_sign_with_compromised_keys_attack,
-      'undo_sign_with_compromised_keys_attack')
-
-
   print('Starting Supplier Repo Services Thread: will now listen on port ' +
       str(demo.MAIN_REPO_SERVICE_PORT))
   xmlrpc_service_thread = threading.Thread(target=server.serve_forever)

--- a/demo/demo_image_repo.py
+++ b/demo/demo_image_repo.py
@@ -369,6 +369,13 @@ def undo_mitm_arbitrary_package_attack(target_filepath):
 
 
 def keyed_arbitrary_package_attack(target_filepath):
+  """
+  Add a new, malicious target to the Image Repository and sign malicious
+  metadata with the valid Image Repository timestamp, snapshot, and targets
+  keys.
+
+  This attack is described in README.md, section 3.5.
+  """
   # TODO: Back up the image first.
   if not os.path.exists(target_filepath):
     raise uptane.Error('Unable to attack: expected given image filename, ' +
@@ -386,6 +393,17 @@ def keyed_arbitrary_package_attack(target_filepath):
 
 
 def undo_keyed_arbitrary_package_attack(target_filepath):
+  """
+  Recover from keyed_arbitrary_package_attack.
+
+  1. Revoke existing timestamp, snapshot, and targets keys, and issue new
+     keys to replace them. This uses the root key for the Image Repository,
+     which should be an offline key.
+  2. Replace the malicious target the attacker added with a clean version of
+     the target, as it was before the attack.
+
+  This attack recovery is described in README.md, section 3.6.
+  """
   # Revoke potentially compromised keys, replacing them with new keys.
   revoke_compromised_keys()
 
@@ -498,6 +516,11 @@ def revoke_compromised_keys():
 
 
 def kill_server():
+  """
+  Kills the forked process that is hosting the Image Repository via
+  Python's simple HTTP server. This does not affect anything in the repository
+  at all. host() can be run afterwards to begin hosting again.
+  """
   global server_process
   if server_process is None:
     print('No server to stop.')

--- a/demo/demo_image_repo.py
+++ b/demo/demo_image_repo.py
@@ -428,14 +428,14 @@ def undo_keyed_arbitrary_package_attack(target_filepath):
 
   This attack recovery is described in README.md, section 3.6.
   """
-  print('UNDO ATACK: keyed arbitrary package attack on target_filepath ' +
+  print('UNDO ATTACK: keyed arbitrary package attack on target_filepath ' +
       repr(target_filepath))
 
   # Revoke potentially compromised keys, replacing them with new keys.
   revoke_compromised_keys()
 
   # Replace malicious target with original.
-  dd.add_target_and_write_to_live(filename=target_filepath,
+  add_target_and_write_to_live(filename=target_filepath,
       file_content='Fresh firmware image')
 
   print('COMPLETED UNDO ATTACK')

--- a/demo/demo_image_repo.py
+++ b/demo/demo_image_repo.py
@@ -299,6 +299,9 @@ def mitm_arbitrary_package_attack(target_filepath):
   # Simulate an arbitrary package attack by a Man in the Middle, without
   # compromising keys.  Move evil target file into place on the image
   # repository, without updating metadata.
+  print('UNDO ATTACK: arbitrary package, no keys, on target ' +
+      repr(target_filepath))
+
   full_target_filepath = os.path.join(demo.MAIN_REPO_TARGETS_DIR, target_filepath)
 
   # TODO: NOTE THAT THIS ATTACK SCRIPT BREAKS IF THE TARGET FILE IS IN A
@@ -348,8 +351,8 @@ def undo_mitm_arbitrary_package_attack(target_filepath):
   mitm_arbitrary_package_attack().
   Move the evil target file out and normal target file back in.
   """
-  print('UNDO ATTACK: arbitrary package, no keys, on VIN ' + repr(vin) + ', '
-      'target_filepath ' + repr(target_filepath))
+  print('UNDO ATTACK: arbitrary package, no keys, on target ' +
+      repr(target_filepath))
 
   full_target_filepath = os.path.join(demo.MAIN_REPO_TARGETS_DIR, target_filepath)
 
@@ -381,9 +384,8 @@ def keyed_arbitrary_package_attack(target_filepath):
 
   This attack is described in README.md, section 3.5.
   """
-  print('ATTACK: keyed_arbitrary_package_attack with parameters '
-      ': vin ' + repr(vin) + '; ecu_serial ' + repr(ecu_serial) + '; '
-      'target_filepath ' + repr(target_filepath))
+  print('ATTACK: keyed_arbitrary_package_attack on target_filepath ' +
+      repr(target_filepath))
 
 
   # TODO: Back up the image and then restore it in the undo function instead of
@@ -426,9 +428,8 @@ def undo_keyed_arbitrary_package_attack(target_filepath):
 
   This attack recovery is described in README.md, section 3.6.
   """
-  print('UNDO ATACK: keyed arbitrary package attack with parameters '
-      ': vin ' + repr(vin) + '; ecu_serial ' + repr(ecu_serial) + '; '
-      'target_filepath ' + repr(target_filepath))
+  print('UNDO ATACK: keyed arbitrary package attack on target_filepath ' +
+      repr(target_filepath))
 
   # Revoke potentially compromised keys, replacing them with new keys.
   revoke_compromised_keys()

--- a/demo/demo_image_repo.py
+++ b/demo/demo_image_repo.py
@@ -263,11 +263,31 @@ def listen():
   # Register functions that can be called via XML-RPC, allowing users to add
   # target files to the image repository or to simulate attacks from a web
   # frontend.
-  server.register_function(add_target_to_imagerepo, 'add_target_to_supplier_repo')
+  server.register_function(add_target_to_imagerepo,
+      'add_target_to_supplier_repo')
   server.register_function(write_to_live, 'write_supplier_repo')
-  server.register_function(mitm_arbitrary_package_attack, 'mitm_arbitrary_package_attack')
+
+  # Attack 1: Arbitrary Package, no keys
+  server.register_function(mitm_arbitrary_package_attack,
+      'mitm_arbitrary_package_attack')
   server.register_function(undo_mitm_arbitrary_package_attack,
       'undo_mitm_arbitrary_package_attack')
+
+  # Attack 2:
+  # We don't bother performing the replay attack against the Image Repo;
+  # demonstration on the Director Repo is enough.
+
+  # Attack 3: Arbitrary Package, keyed
+  server.register_function(keyed_arbitrary_package_attack,
+      'keyed_arbitrary_package_attack')
+  server.register_function(undo_keyed_arbitrary_package_attack,
+      'undo_keyed_arbitrary_package_attack')
+
+  # Attack 4: Arbitrary Package, Revoked Key
+  server.register_function(sign_with_compromised_keys_attack,
+      'sign_with_compromised_keys_attack')
+  server.register_function(undo_sign_with_compromised_keys_attack,
+      'undo_sign_with_compromised_keys_attack')
 
   print('Starting Supplier Repo Services Thread: will now listen on port ' +
       str(demo.MAIN_REPO_SERVICE_PORT))
@@ -320,6 +340,8 @@ def mitm_arbitrary_package_attack(target_filepath):
 
       if os.path.exists(evil_file_in_director_repo):
         os.remove(evil_file_in_director_repo)
+
+
 
 
 


### PR DESCRIPTION
Add high-level functions that execute new attacks in the demonstration and make them available via XML-RPC to the web frontend.

[Edited by @vladimir.v.diaz to list the attacks added in this pull request]

Attacks added to Director repository:
```
- prepare_replay_attack_nokeys
- replay_attack_nokeys
- undo_replay_attack_nokeys

- keyed_arbitrary_package_attack
- undo_keyed_arbitrary_package_attack
```

Attacks added to Image repository:
```
- keyed_arbitrary_package_attack
- undo_keyed_arbitrary_package_attack
```

