### PR TITLE
Remove unnecessary use of globals and global keyword

### DIFF
--- a/demo/demo_director.py
+++ b/demo/demo_director.py
@@ -56,7 +56,6 @@ import atexit # to kill server process on exit()
 KNOWN_VINS = ['111', '112', '113', 'democar']
 
 # Dynamic global objects
-#repo = None
 repo_server_process = None
 director_service_instance = None
 director_service_thread = None
@@ -319,8 +318,6 @@ def revoke_compromised_keys():
     None.
   """
 
-  global director_service_instance
-
   # Generate news keys for the Targets, Snapshot, and Timestamp roles.  Make
   # sure that the director service instance is updated to use the new keys.
   # The 'director' name actually references the targets role.
@@ -420,9 +417,6 @@ def sign_with_compromised_keys_attack():
   <Returns>
     None.
   """
-
-  global director_service_instance
-
   print('ATTACK: arbitrary metadata, old key, all vehicles')
 
   # Start by backing up the repository before the attack occurs so that we
@@ -507,10 +501,6 @@ def undo_sign_with_compromised_keys_attack():
   <Returns>
     None.
   """
-
-  global director_service_instance
-
-
   # Re-load the valid keys, so that the repository objects can be updated to
   # reference them and replace the compromised keys set.
   valid_targets_private_key = demo.import_private_key('new_director')
@@ -572,8 +562,6 @@ def add_target_to_director(target_fname, filepath_in_repo, vin, ecu_serial):
       Complies with uptane.formats.ECU_SERIAL_SCHEMA
 
   """
-  global director_service_instance
-
   uptane.formats.VIN_SCHEMA.check_match(vin)
   uptane.formats.ECU_SERIAL_SCHEMA.check_match(ecu_serial)
   tuf.formats.RELPATH_SCHEMA.check_match(target_fname)

--- a/demo/demo_image_repo.py
+++ b/demo/demo_image_repo.py
@@ -138,8 +138,6 @@ def clean_slate(use_new_keys=False):
 
 def write_to_live():
 
-  global repo
-
   # Write the metadata files out to the Image Repository's 'metadata.staged'
   repo.mark_dirty(['timestamp', 'snapshot'])
   repo.write() # will be writeall() in most recent TUF branch
@@ -171,8 +169,6 @@ def add_target_to_imagerepo(target_fname, filepath_in_repo):
       subdirectory of the repository directory.  This doesn't employ
       delegations, which would have to be done manually.
   """
-  global repo
-
   tuf.formats.RELPATH_SCHEMA.check_match(target_fname)
 
 
@@ -490,8 +486,6 @@ def revoke_compromised_keys():
   <Returns>
     None.
   """
-
-  global repo
 
   # Grab the old public keys.
   old_targets_public_key = demo.import_public_key('maintargets')

--- a/demo/demo_primary.py
+++ b/demo/demo_primary.py
@@ -268,9 +268,6 @@ def update_cycle():
   """
   """
 
-  global primary_ecu
-
-
   #
   # FIRST: TIME
   #
@@ -364,7 +361,6 @@ def update_cycle():
 
 def generate_signed_vehicle_manifest():
 
-  global primary_ecu
   global most_recent_signed_vehicle_manifest
 
   # Generate and sign a manifest indicating that this ECU has a particular

--- a/demo/demo_secondary.py
+++ b/demo/demo_secondary.py
@@ -53,7 +53,6 @@ _ecu_serial = '22222'
 _primary_host = demo.PRIMARY_SERVER_HOST
 _primary_port = demo.PRIMARY_SERVER_DEFAULT_PORT
 firmware_filename = 'secondary_firmware.txt'
-current_firmware_fileinfo = {}
 secondary_ecu = None
 ecu_key = None
 nonce = None
@@ -79,7 +78,6 @@ def clean_slate(
   global _primary_port
   global nonce
   global client_directory
-  global attacks_detected
 
   _vin = vin
   _ecu_serial = ecu_serial
@@ -269,8 +267,6 @@ def update_cycle():
   tuf and uptane errors if metadata or the image don't validate.
   """
 
-  global secondary_ecu
-  global current_firmware_fileinfo
   global attacks_detected
 
   # Connect to the Primary
@@ -504,7 +500,6 @@ def update_cycle():
 
 def generate_signed_ecu_manifest():
 
-  global secondary_ecu
   global most_recent_signed_ecu_manifest
   global attacks_detected
 

--- a/tests/test_primary.py
+++ b/tests/test_primary.py
@@ -58,14 +58,20 @@ nonce = 5
 vin = '000'
 primary_ecu_serial = '00000'
 
-# Initialize these in setUpModule below.
-primary_ecu_key = None
-key_timeserver_pub = None
-key_timeserver_pri = None
-clock = None
-process_timeserver = None
-process_director = None
-process_oemrepo = None
+# Load the private key for this Primary ECU.
+primary_ecu_key = uptane.common.canonical_key_from_pub_and_pri(
+    demo.import_public_key('primary'), demo.import_private_key('primary'))
+
+# Generate a trusted initial time for the Primary.
+clock = tuf.formats.unix_timestamp_to_datetime(int(time.time()))
+clock = clock.isoformat() + 'Z'
+tuf.formats.ISO8601_DATETIME_SCHEMA.check_match(clock)
+
+# Load the public timeserver key.
+key_timeserver_pub = demo.import_public_key('timeserver')
+key_timeserver_pri = demo.import_private_key('timeserver')
+
+
 
 
 
@@ -81,41 +87,8 @@ def destroy_temp_dir():
 def setUpModule():
   """
   This is run once for the full module, before all tests.
-  It prepares some globals, including a single Primary ECU client instance.
-  When finished, it will also start up an OEM Repository Server,
-  Director Server, and Time Server. Currently, it requires them to be already
-  running.
   """
-  global primary_ecu_key
-  global key_timeserver_pub
-  global key_timeserver_pri
-  global clock
-
   destroy_temp_dir()
-
-  # Load the private key for this Primary ECU.
-  key_pub = demo.import_public_key('primary')
-  key_pri = demo.import_private_key('primary')
-  primary_ecu_key = uptane.common.canonical_key_from_pub_and_pri(
-      key_pub, key_pri)
-
-  # Load the public timeserver key.
-  key_timeserver_pub = demo.import_public_key('timeserver')
-  key_timeserver_pri = demo.import_private_key('timeserver')
-
-  # Generate a trusted initial time for the Primary.
-  clock = tuf.formats.unix_timestamp_to_datetime(int(time.time()))
-  clock = clock.isoformat() + 'Z'
-  tuf.formats.ISO8601_DATETIME_SCHEMA.check_match(clock)
-
-  # Currently in development.
-
-  # Start the timeserver, director, and oem repo for this test,
-  # using subprocesses, and saving those processes as:
-  #process_timeserver
-  #process_director
-  #process_oemrepo
-  # to be stopped in tearDownModule below.
 
 
 


### PR DESCRIPTION
*[Updated]*

The "global" keyword is only necessary when a module-level name is going
to be reassigned, at module level.

E.g. it's necessary here:
```
def fn():
  global x
  x = new_thing
```

But it is not generally necessary here:
```
def fn():
  x.some_method_that_changes_the_object()
```

Nor here:
```
def fn():
  some_method_that_changes_something(x)
```

Nor here:
```
def fn():
  x.element = new_thing
```


So I've removed its unnecessary use in such cases.

I also removed a global variable that was never used in the demo Secondary, and moved several initializations in `test_primary.py` out of separate functions and to module level (making global keywords unnecessary in further functions in `test_primary`).
