### PR TITLE
Write proper docstrings for the client modules

### DIFF
--- a/uptane/clients/primary.py
+++ b/uptane/clients/primary.py
@@ -3,9 +3,18 @@
   primary.py
 
 <Purpose>
-  An Uptane client modeling the behavior of a Primary ECU to distribute updates
-  to Secondaries, collect ECU manifests, generate timeserver requests, etc.
+  Provides core functionality for Uptane Primary ECU clients:
+  - Obtains and performs full verification of metadata and images, employing
+    TUF (The Update Framework)
+  - Prepares metadata and images for distribution to Secondaries
+  - Receives ECU Manifests and holds them for the next Vehicle Manifest
+  - Generates Vehicle Manifests
+  - Receives nonces from Secondaries; maintains and cycles a list of nonces
+    for use in requests for signed time from the Timeserver
 
+  A detailed explanation of the role of the Primary in Uptane is available in
+  the "Design Overview" and "Implementation Specification" documents, links to
+  which are maintained at uptane.github.io
 """
 from __future__ import print_function
 from __future__ import unicode_literals

--- a/uptane/clients/primary.py
+++ b/uptane/clients/primary.py
@@ -37,8 +37,11 @@ import uptane.services.director as director
 import uptane.services.timeserver as timeserver
 import uptane.encoding.asn1_codec as asn1_codec
 
-from demo.uptane_banners import *
 from uptane import GREEN, RED, YELLOW, ENDCOLORS
+
+# The following import is a temporary measure to facilitate demonstration.
+# It does not ultimately belong here in the reference implementation.
+from demo.uptane_banners import *
 
 
 log = uptane.logging.getLogger('primary')

--- a/uptane/clients/primary.py
+++ b/uptane/clients/primary.py
@@ -91,17 +91,6 @@ class Primary(object): # Consider inheriting from Secondary and refactoring.
       This is a list of all ECU Serials belonging to Secondaries of this
       Primary.
 
-      # # TODO: <~> This next field makes assumptions that are not in the Uptane
-      # #           specification, to handle some Sam code. Remove the assumption
-      # #           at some point. (The Primary config enum is outside the spec.)
-      # This is a dictionary with an entry for every Secondary that this Primary
-      # communicates with.
-      # The dictionary maps ecu_serial to that ECU's number in the enumeration
-      # in the Primary's config file, for communication purposes.
-      # e.g. {
-      #     'ecuserial1234': 0,
-      #     'ecuserial5678': 1}
-
     assigned_targets:
       A dict mapping ECU Serial to the target file info that the Director has
       instructed that ECU to install.
@@ -277,16 +266,6 @@ class Primary(object): # Consider inheriting from Secondary and refactoring.
 
 
   def get_target_list_from_director(self):
-    # TODO: <~> SHOULD FIX FOR PRODUCTION! Note that this assumes that the
-    # Director is conveying information directly in its "targets" role.
-    # This is not something we can assume - Director repo structure is not
-    # required to be that flat. We could pull all targets from all roles and
-    # then retrieve all Director-validated target info (that step to ensure
-    # that we're not including targets listed by roles that haven't been
-    # delegated control over those filepaths).
-    # For the time being, the design here requires that the Director role
-    # structure have no delegations in it.
-
     # TODO: This will have to be changed (along with the functions that depend
     # on this function's output) once multi-role delegations can yield multiple
     # targetfile_info objects. (Currently, we only yield more than one at the
@@ -502,17 +481,6 @@ class Primary(object): # Consider inheriting from Secondary and refactoring.
 
     # For each target for which we have verified metadata:
     for target in verified_targets:
-
-      # No longer need this.
-      # # We work with the fileinfo from the Director repository, since the
-      # # fileinfos returned are guaranteed to be identical in all regards except
-      # # for the custom field, and the only custom field we care about is from
-      # # the Director. Grab that targetfile info.
-      # # TODO: Clean up this assertion so that an appropriate error is raised.
-      # assert self.director_repo_name in target_dict, \
-      #     'Programming error: expected target info from repository: ' + \
-      #     self.director_repo_name
-      # target = target_dict[self.director_repo_name]
 
       tuf.formats.TARGETFILE_SCHEMA.check_match(target) # redundant, defensive
 
@@ -765,7 +733,7 @@ class Primary(object): # Consider inheriting from Secondary and refactoring.
 
 
 
-  def generate_signed_vehicle_manifest(self):#, use_json=False):
+  def generate_signed_vehicle_manifest(self):
     """
     Put ECU manifests into a vehicle manifest and sign it.
     Support multiple manifests from the same ECU.
@@ -814,16 +782,6 @@ class Primary(object): # Consider inheriting from Secondary and refactoring.
     self.ecu_manifests = dict()
 
     return signable_vehicle_manifest
-
-    # if use_json:
-    #   return signed_vehicle_manifest
-
-    # # TODO: Once the ber encoder functions are done, do this:
-    # original_signed_vehicle_manifest = signed_vehicle_manifest
-    # ber_signed_vehicle_manifest = ber_encoder.ber_encode_signable_object(
-    #     signed_vehicle_manifest)
-
-    # return ber_signed_vehicle_manifest
 
 
 
@@ -1107,10 +1065,9 @@ class Primary(object): # Consider inheriting from Secondary and refactoring.
 
 def enforce_jail(fname, expected_containing_dir):
   """
-  DO NOT ASSUME THAT THIS TEMPORARY FUNCTION IS SECURE.
+  DO NOT ASSUME THAT THIS FUNCTION IS SECURE.
   """
   # Make sure it's in the expected directory.
-  #print('provided arguments: ' + repr(fname) + ' and ' + repr(expected_containing_dir))
   abs_fname = os.path.abspath(os.path.join(expected_containing_dir, fname))
   if not abs_fname.startswith(os.path.abspath(expected_containing_dir)):
     raise ValueError('Expected a filename in directory ' +

--- a/uptane/clients/primary.py
+++ b/uptane/clients/primary.py
@@ -433,8 +433,8 @@ class Primary(object): # Consider inheriting from Secondary and refactoring.
       # repos couldn't provide validated target file info, we'd have caught an
       # error earlier instead.
 
-      raise tuf.Error('Unexpected behavior: did not receive target info from '
-          'Director repository (' + repr(self.director_repo_name) + ') for '
+      raise uptane.Error('Unexpected behavior: did not receive target info from'
+          ' Director repository (' + repr(self.director_repo_name) + ') for '
           'a target (' + repr(target_filepath) + '). Is pinned.json configured '
           'to allow some targets to validate without Director approval, or is'
           'the wrong repository specified as the Director repository in the '

--- a/uptane/clients/primary.py
+++ b/uptane/clients/primary.py
@@ -317,6 +317,14 @@ class Primary(object): # Consider inheriting from Secondary and refactoring.
 
 
   def refresh_toplevel_metadata_from_repositories(self):
+    """
+    Refreshes client's metadata for the top-level roles:
+      root, targets, snapshot, and timestamp
+
+    See tuf.client.updater.Updater.refresh() for details, or the
+    Uptane Implementation Specification, section 8.3.2 (Full Verification of
+    Metadata).
+    """
     self.updater.refresh()
 
 
@@ -324,6 +332,11 @@ class Primary(object): # Consider inheriting from Secondary and refactoring.
 
 
   def get_target_list_from_director(self):
+    """
+    This method extracts the Director's instructions from the targets role in
+    the Director repository's metadata. These must still be validated against
+    the Image Repository in further calls.
+    """
     # TODO: This will have to be changed (along with the functions that depend
     # on this function's output) once multi-role delegations can yield multiple
     # targetfile_info objects. (Currently, we only yield more than one at the
@@ -380,6 +393,13 @@ class Primary(object): # Consider inheriting from Secondary and refactoring.
         will be raised by the updater.target() call here if we are unable to
         validate reliable target info for the target file specified (if the
         repositories do not agree, or we could not reach them, or so on).
+
+      uptane.Error
+        if the Director targets file has not provided information about the
+        given target_filepath, but target_filepath has nevertheless been
+        validated. This could happen if the map/pinning file for some reason
+        incorrectly set to not require metadata from the Director.
+
     """
     tuf.formats.RELPATH_SCHEMA.check_match(target_filepath)
 

--- a/uptane/clients/primary.py
+++ b/uptane/clients/primary.py
@@ -1070,14 +1070,15 @@ class Primary(object): # Consider inheriting from Secondary and refactoring.
 
   def save_distributable_metadata_files(self):
     """
-    # TODO: Docstring.
+    Generates a zip archive of the metadata files validated by this Primary,
+    for distribution to full verifying Secondaries. The particular method of
+    distributing this metadata to Secondaries will vary greatly depending on
+    one's setup, and is left to implementers.
     """
 
     metadata_base_dir = os.path.join(self.full_client_dir, 'metadata')
 
-
-    # Save a gzipped version of all of the metadata.
-    # TODO: <~> Update this for ASN.1 / DER.
+    # Save a zipped version of all of the metadata.
     # Note that some stale metadata may be retained, but should never affect
     # security. Worth confirming.
     # What we want here, basically, is:

--- a/uptane/clients/secondary.py
+++ b/uptane/clients/secondary.py
@@ -190,8 +190,10 @@ class Secondary(object):
 
 
   def _create_nonce(self):
-    """Returns a pseudorandom number for use in protecting from replay attacks
-    from the timeserver (or an intervening party)."""
+    """
+    Returns a pseudorandom number for use in protecting from replay attacks
+    from the timeserver (or an intervening party).
+    """
     return random.randint(
         uptane.formats.NONCE_LOWER_BOUND, uptane.formats.NONCE_UPPER_BOUND)
 
@@ -422,7 +424,6 @@ class Secondary(object):
     Pick out the target file(s) with our ECU serial listed
     Fully validate the metadata for the target file(s)
     """
-    #
     tuf.formats.RELPATH_SCHEMA.check_match(metadata_archive_fname)
 
     self._expand_metadata_archive(metadata_archive_fname)
@@ -525,20 +526,6 @@ class Secondary(object):
       tuf.client.updater.hard_check_file_length(
           fobj,
           relevant_targetinfo['fileinfo']['length'])
-
-      # # Read the entire contents of 'file_object', a 'tuf.util.TempFile' file-
-      # # like object that ensures the entire file is read.
-      # observed_length = len(fobj.read())
-
-      # trusted_file_length = relevant_targetinfo['fileinfo']['length']
-
-      # if observed_length != trusted_file_length:
-      #   raise tuf.DownloadLengthMismatchError(
-      #       trusted_file_length, observed_length)
-
-      # else:
-      #   log.debug('Observed length (' + repr(observed_length) +
-      #       ') == trusted length (' + repr(trusted_file_length) + ')')
 
     # Check file hashes against trusted target info.
     with open(full_image_fname, 'rb') as fobj:

--- a/uptane/clients/secondary.py
+++ b/uptane/clients/secondary.py
@@ -125,9 +125,10 @@ class Secondary(object):
     uptane.formats.VIN_SCHEMA.check_match(vin)
     uptane.formats.ECU_SERIAL_SCHEMA.check_match(ecu_serial)
     tuf.formats.ISO8601_DATETIME_SCHEMA.check_match(time)
-    for key in [timeserver_public_key, director_public_key]:
-      if key is not None:
-        tuf.formats.ANYKEY_SCHEMA.check_match(key)
+    tuf.formats.ANYKEY_SCHEMA.check_match(timeserver_public_key)
+    tuf.formats.ANYKEY_SCHEMA.check_match(ecu_key)
+    if director_public_key is not None:
+        tuf.formats.ANYKEY_SCHEMA.check_match(director_public_key)
 
     self.director_repo_name = director_repo_name
     self.ecu_key = ecu_key
@@ -144,6 +145,11 @@ class Secondary(object):
       raise uptane.Error('Secondary not set as partial verifying, but a director ' # TODO: Choose error class.
           'key was still provided. Full verification secondaries employ the '
           'normal TUF verifications rooted at root metadata files.')
+
+    elif self.partial_verifying and self.director_public_key is None:
+      raise uptane.Error('Secondary set as partial verifying, but a director '
+          'key was not provided. Partial verification Secondaries validate '
+          'only the ')
 
 
     # Create a TAP-4-compliant updater object. This will read pinning.json

--- a/uptane/clients/secondary.py
+++ b/uptane/clients/secondary.py
@@ -121,7 +121,7 @@ class Secondary(object):
   def __init__(
     self,
     full_client_dir,
-    director_repo_name, # e.g. 'director'; value must appear in pinning file
+    director_repo_name,
     vin,
     ecu_serial,
     ecu_key,
@@ -551,6 +551,4 @@ class Secondary(object):
     # validated and we can return.
     log.debug('Delivered target file has been fully validated: ' +
         repr(full_image_fname))
-
-
 

--- a/uptane/clients/secondary.py
+++ b/uptane/clients/secondary.py
@@ -256,6 +256,10 @@ class Secondary(object):
     # each repository.
     self.updater = tuf.client.updater.Updater('updater')
 
+    if director_repo_name not in self.updater.pinned_metadata['repositories']:
+      raise uptane.Error('Given name for the Director repository is not a '
+          'known repository, according to the pinned metadata from pinned.json')
+
     # We load the given time twice for simplicity in later code.
     self.all_valid_timeserver_times = [time, time]
 

--- a/uptane/clients/secondary.py
+++ b/uptane/clients/secondary.py
@@ -3,10 +3,20 @@
   secondary.py
 
 <Purpose>
-  A module providing functionality for an Uptane Secondary ECU client
-  performing full metadata verification, as would be performed during ECU boot.
-  Also includes some partial verification functionality.
+  Provides core functionality for Uptane Secondary ECU clients:
+  - Given an archive of metadata and an image file, performs full verification
+    of both, employing TUF (The Update Framework), determining if this
+    Secondary ECU has been instructed to install the image by the Director and
+    if the image is also valid per the Image Repository.
+  - Generates ECU Manifests describing the state of the Secondary for Director
+    perusal
+  - Generates nonces for time requests from the Timeserver, and validates
+    signed times provided by the Timeserver, maintaining trustworthy times.
+    Rotates nonces after they have appeared in Timeserver responses.
 
+  A detailed explanation of the role of the Secondary in Uptane is available in
+  the "Design Overview" and "Implementation Specification" documents, links to
+  which are maintained at uptane.github.io
 """
 from __future__ import print_function
 from __future__ import unicode_literals

--- a/uptane/clients/secondary.py
+++ b/uptane/clients/secondary.py
@@ -20,23 +20,25 @@
 """
 from __future__ import print_function
 from __future__ import unicode_literals
-from io import open
-
-import uptane
-import uptane.formats
-import uptane.common
-import uptane.encoding.asn1_codec as asn1_codec
-import hashlib
-
-import tuf.client.updater
-import tuf.formats
-import tuf.keys
-import tuf.repository_tool as rt
+from io import open # TODO: Determine if this should be here.
 
 import os # For paths and makedirs
 import shutil # For copyfile
 import random # for nonces
 import zipfile # to expand the metadata archive retrieved from the Primary
+import hashlib
+
+import tuf.formats
+import tuf.keys
+import tuf.client.updater
+import tuf.repository_tool as rt
+
+import uptane
+import uptane.formats
+import uptane.common
+import uptane.encoding.asn1_codec as asn1_codec
+
+
 from uptane import GREEN, RED, YELLOW, ENDCOLORS
 
 


### PR DESCRIPTION
The docstrings in primary.py and secondary.py were certainly inadequate for a reference implementation. I think that the commits here will make them respectable and more helpful to an implementer reading through the reference implementation.