### PR TITLE
Import uptane first, to avoid potential tuf configuration issues

### DIFF
--- a/demo/__init__.py
+++ b/demo/__init__.py
@@ -3,7 +3,7 @@ __init__.py for the Uptane demo package
 """
 from __future__ import unicode_literals
 
-import uptane
+import uptane # Import before TUF modules; may change tuf.conf values.
 import os
 import tuf.formats
 import tuf.repository_tool as rt

--- a/demo/demo_director.py
+++ b/demo/demo_director.py
@@ -34,7 +34,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import demo
-import uptane
+import uptane # Import before TUF modules; may change tuf.conf values.
 import uptane.services.director as director
 import uptane.services.inventorydb as inventory
 import tuf.formats

--- a/demo/demo_image_repo.py
+++ b/demo/demo_image_repo.py
@@ -28,7 +28,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import demo
-import uptane
+import uptane # Import before TUF modules; may change tuf.conf values.
 import uptane.formats
 import tuf.formats
 

--- a/demo/demo_primary.py
+++ b/demo/demo_primary.py
@@ -20,7 +20,7 @@ from __future__ import unicode_literals
 from io import open
 
 import demo
-import uptane
+import uptane # Import before TUF modules; may change tuf.conf values.
 import uptane.common # for canonical key construction and signing
 import uptane.clients.primary as primary
 import uptane.encoding.asn1_codec as asn1_codec

--- a/demo/demo_secondary.py
+++ b/demo/demo_secondary.py
@@ -27,7 +27,7 @@ from __future__ import unicode_literals
 from io import open
 
 import demo
-import uptane
+import uptane # Import before TUF modules; may change tuf.conf values.
 import uptane.common # for canonical key construction and signing
 import uptane.clients.secondary as secondary
 from uptane import GREEN, RED, YELLOW, ENDCOLORS

--- a/tests/test_der_encoder.py
+++ b/tests/test_der_encoder.py
@@ -9,10 +9,10 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import uptane # Import before TUF modules; may change tuf.conf values.
 import tuf.formats
 import tuf.keys
 import tuf.repository_tool as repo_tool
-import uptane
 import uptane.formats
 import uptane.common
 

--- a/tests/test_primary.py
+++ b/tests/test_primary.py
@@ -12,11 +12,7 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import uptane
-import uptane.formats
-import uptane.clients.primary as primary
-import uptane.common
-import uptane.encoding.asn1_codec as asn1_codec
+import uptane # Import before TUF modules; may change tuf.conf values.
 
 from six.moves.urllib.error import URLError
 
@@ -31,6 +27,10 @@ import time
 import copy
 import shutil
 import hashlib
+import uptane.formats
+import uptane.clients.primary as primary
+import uptane.common
+import uptane.encoding.asn1_codec as asn1_codec
 
 # For temporary convenience:
 import demo # for generate_key, import_public_key, import_private_key

--- a/uptane/clients/primary.py
+++ b/uptane/clients/primary.py
@@ -19,6 +19,8 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import uptane # Import before TUF modules; may change tuf.conf values.
+
 import os # For paths and makedirs
 import shutil # For copyfile
 import random # for nonces

--- a/uptane/clients/secondary.py
+++ b/uptane/clients/secondary.py
@@ -22,6 +22,8 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from io import open # TODO: Determine if this should be here.
 
+import uptane # Import before TUF modules; may change tuf.conf values.
+
 import os # For paths and makedirs
 import shutil # For copyfile
 import random # for nonces
@@ -33,7 +35,6 @@ import tuf.keys
 import tuf.client.updater
 import tuf.repository_tool as rt
 
-import uptane
 import uptane.formats
 import uptane.common
 import uptane.encoding.asn1_codec as asn1_codec

--- a/uptane/common.py
+++ b/uptane/common.py
@@ -5,6 +5,7 @@ the future.
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import uptane # Import before TUF modules; may change tuf.conf values.
 import tuf
 import tuf.formats
 import json
@@ -18,7 +19,6 @@ import hashlib
 # signature-related functions into a new module (sig or something) that
 # imports asn1_codec.
 import uptane.encoding.asn1_codec as asn1_codec
-import uptane
 import uptane.formats
 
 # Both key types below are supported, but issues may be encountered with RSA

--- a/uptane/encoding/asn1_codec.py
+++ b/uptane/encoding/asn1_codec.py
@@ -17,6 +17,7 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import uptane # Import before TUF modules; may change tuf.conf values. 
 import tuf
 import tuf.conf
 import tuf.formats

--- a/uptane/formats.py
+++ b/uptane/formats.py
@@ -9,6 +9,8 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import uptane # Import before TUF modules; may change tuf.conf values.
+
 # We will have a superset of formats in TUF
 from tuf.formats import *
 import tuf.schema as SCHEMA

--- a/uptane/services/director.py
+++ b/uptane/services/director.py
@@ -30,7 +30,7 @@
 """
 from __future__ import unicode_literals
 
-import uptane
+import uptane # Import before TUF modules; may change tuf.conf values.
 import uptane.formats
 import uptane.common
 import uptane.services.inventorydb as inventory

--- a/uptane/services/inventorydb.py
+++ b/uptane/services/inventorydb.py
@@ -115,7 +115,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from io import open
 
-import uptane
+import uptane # Import before TUF modules; may change tuf.conf values. 
 import uptane.formats
 import tuf
 

--- a/uptane/services/timeserver.py
+++ b/uptane/services/timeserver.py
@@ -10,7 +10,7 @@
 """
 from __future__ import unicode_literals
 
-import uptane
+import uptane # Import before TUF modules; may change tuf.conf values.
 import uptane.formats
 import uptane.common
 import uptane.encoding.asn1_codec as asn1_codec


### PR DESCRIPTION
Add comment to `import uptane` lines and make sure that Uptane (`uptane/__init__.py`) is imported first, in order to avoid a situation in which TUF is imported, TUF is configured, those configuration options percolate into other settings in other TUF modules, and then Uptane overrides the original TUF setting.

Example: could happen with tuf.conf.METADATA_FORMAT previously, where e.g. repository_lib and client/updater cached that variable as METADATA_EXTENSION, potentially before Uptane loaded and changed the original variable, resulting in different parts of TUF thinking that the METADATA_FORMAT was different.