### PR TITLE
Primary will no longer always provide JSON time attestation

### DIFF
--- a/demo/demo_primary.py
+++ b/demo/demo_primary.py
@@ -687,11 +687,13 @@ def get_time_attestation_for_ecu(ecu_serial):
     #     repr(ecu_serial) + ') does not appear in the mapping of ECU Serials '
     #     'to CAN IDs. Sending time attestation back.')
 
-    print('Distributing time attestation to ECU ' + repr(ecu_serial))
+    attestation = primary_ecu.get_last_timeserver_attestation()
+
     # If we're using ASN.1/DER, then the attestation is binary data we're about
     # to transmit via XMLRPC, so we should wrap it appropriately:
-    attestation = xmlrpc_client.Binary(
-        primary_ecu.get_last_timeserver_attestation())
+    if tuf.conf.METADATA_FORMAT == 'der':
+      attestation = xmlrpc_client.Binary(attestation)
+
     return attestation
 
 

--- a/demo/demo_primary.py
+++ b/demo/demo_primary.py
@@ -688,6 +688,10 @@ def get_time_attestation_for_ecu(ecu_serial):
     #     'to CAN IDs. Sending time attestation back.')
 
     print('Distributing time attestation to ECU ' + repr(ecu_serial))
+    # If we're using ASN.1/DER, then the attestation is binary data we're about
+    # to transmit via XMLRPC, so we should wrap it appropriately:
+    attestation = xmlrpc_client.Binary(
+        primary_ecu.get_last_timeserver_attestation())
     return attestation
 
 

--- a/demo/demo_secondary.py
+++ b/demo/demo_secondary.py
@@ -279,6 +279,13 @@ def update_cycle():
 
   # Download the time attestation from the Primary.
   time_attestation = pserver.get_last_timeserver_attestation()
+  if tuf.conf.METADATA_FORMAT == 'der':
+    # Binary data transfered via XMLRPC has to be wrapped in an xmlrpc Binary
+    # object. The data itself is contained in attribute 'data'.
+    # When running the demo using ASN.1/DER mode, metadata is in binary, and
+    # so this xmlrpc Binary object is used and the data should be extracted
+    # from it like so:
+    time_attestation = time_attestation.data
 
   # Download the metadata from the Primary in the form of an archive. This
   # returns the binary data that we need to write to file.

--- a/uptane/clients/primary.py
+++ b/uptane/clients/primary.py
@@ -825,7 +825,9 @@ class Primary(object): # Consider inheriting from Secondary and refactoring.
 
     else:
       raise uptane.Error('Unable to convert time attestation as configured. '
-          'Unexpected format setting: ' + repr(tuf.conf.METADATA_FORMAT))
+          'The settings supported for timeserver attestations are "json" and '
+          '"der", but the value of tuf.conf.METADATA_FORMAT is: ' +
+          repr(tuf.conf.METADATA_FORMAT))
 
 
 

--- a/uptane/clients/secondary.py
+++ b/uptane/clients/secondary.py
@@ -380,6 +380,12 @@ class Secondary(object):
 
     If validation is successful, switch to a new nonce for next time.
     """
+    # If we're using ASN.1/DER format, convert the attestation into something
+    # comprehensible (JSON-compatible dictionary) instead.
+    if tuf.conf.METADATA_FORMAT == 'der':
+      timeserver_attestation = asn1_codec.convert_signed_der_to_dersigned_json(
+          timeserver_attestation)
+
     # Check format.
     uptane.formats.SIGNABLE_TIMESERVER_ATTESTATION_SCHEMA.check_match(
         timeserver_attestation)


### PR DESCRIPTION
The Primary correctly received and validated time attestations
in the format configured in tuf.conf.METADATA_FORMAT.

However, the Primary converts time attestations into a
comprehensible JSON-compatible format after receiving and
validating them.

Due to an oversight, the Primary was failing to check the
format setting and (if appropriate) convert time attestations
back into ASN.1/DER before passing them on to the Secondary,
so regardless of the setting and regardless of the format
that Timeserver sent to Primary, Secondaries were always
receiving time attestations in JSON format.

This is now fixed. Accompanying this are the changes
necessary to the demo to allow it to now transfer this
binary data appropriately (wrapping in xmlrpc Binary objects
based on format setting).