### PR TITLE
Add coverage tracking w/ coveralls to tox and travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,10 @@ python:
 #    TOXENV=py27
 
 install:
-    - pip install tox
+    - pip install tox coveralls
 
 script:
     tox
+
+after_success:
+    - coveralls

--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
-# Uptane
-Reference Implementation and demonstration code for [Uptane](https://uptane.org).
+# [Uptane](https://uptane.github.io)
 
-Please note that extensive documentation on design can be found in the following documents:
+Reference Implementation and demonstration code
+
+[![Build Status](https://travis-ci.org/uptane/uptane.png)](https://travis-ci.org/uptane/uptane) [![Coverage Status](https://coveralls.io/repos/uptane/uptane/badge.svg)](https://coveralls.io/r/uptane/uptane)
+
+--------------------------------
+
+Extensive documentation on design can be found in the following documents:
 
 * [Design Overview](https://docs.google.com/document/d/1pBK--40BCg_ofww4GES0weYFB6tZRedAjUy6PJ4Rgzk/edit?usp=sharing)
 * [Implementation Specification](https://docs.google.com/document/d/1wjg3hl0iDLNh7jIRaHl3IXhwm0ssOtDje5NemyTBcaw/edit?usp=sharing)

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,8 @@ envlist = py{27,33,34}
 [testenv]
 deps =
     -rdev-requirements.txt
+    coverage
 
 commands =
-    python tests/runtests.py
+    coverage run --source uptane tests/runtests.py
+    coverage report


### PR DESCRIPTION
Configure `tox` to install `coverage` and run tests through it, collecting code coverage data for the tests, then have Travis-CI push the generated coverage data (in .coverage) to coveralls.

Also adds badges. (The coverage badge won't load until this is merged.)