### PR TITLE
Run tests twice, once in JSON mode and once in ASN.1/DER mode

### DIFF
--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -15,6 +15,32 @@
 
 from unittest import defaultTestLoader, TextTestRunner
 import sys
+import uptane
+
+# Here, we can override the value of tuf.conf.METADATA_FORMAT for all tests we
+# run. It can have values 'json' or 'der', and will change the TUF & Uptane
+# configuration to cause TUF & Uptane to use this metadata format for the tests
+# in this module (by setting tuf.conf.METADATA_FORMAT). When running these
+# tests, it can be set by providing the argument 'json' or 'der' when calling
+# this module:
+# e.g.  python tests/runtests.py json
+# or    python tests/runtests.py der
+# Running this module without an argument will use the default format for
+# Uptane, set in uptane/__init__.py to 'der'.
+if len(sys.argv) > 2:
+  raise uptane.Error('More arguments provided to runtests than allowed. Only '
+      '0 or 1 command line arguments are supported. If provided, the sole '
+      'command line argument for this test module is the metadata format to be '
+      'used, "json" or "der".')
+elif len(sys.argv) == 2:
+  if sys.argv[1] in ['json', 'der']:
+    uptane.tuf.conf.METADATA_FORMAT = sys.argv[1]
+    print('Metadata Format set to ' + repr(sys.argv[1]))
+  else:
+    raise uptane.Error('Command-line argument not understood. Only '
+        '"json" or "der" are allowed. Received: ' + repr(sys.argv[1]))
+
+
 
 suite = defaultTestLoader.discover(start_dir="tests")
 result = TextTestRunner(verbosity=2).run(suite)

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,10 @@
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox" from this directory.
 
+# Note that this will run coverage twice, adding the data from the second
+# run to the first. In the first run, Uptane and TUF will be run in JSON mode,
+# and in the second, they will be run in ASN.1/DER mode.
+
 [tox]
 envlist = py{27,33,34}
 
@@ -12,5 +16,6 @@ deps =
     coverage
 
 commands =
-    coverage run --source uptane tests/runtests.py
+    coverage run --source uptane tests/runtests.py json
+    coverage run --source uptane -a tests/runtests.py der
     coverage report


### PR DESCRIPTION
via tox, combining the results in coverage.

This involves:
- Update runtests so that it takes an argument: the metadata format to use, which it then overrides tuf.conf.METADATA_FORMAT with
- Update tox config to run runtests.py twice, once with 'der' and once with 'json' arguments
- Have coverage combine the data from the two runs by using the -a argument.