### PR TITLE
Fix file not closed warnings

### DIFF
--- a/demo/demo_primary.py
+++ b/demo/demo_primary.py
@@ -209,9 +209,8 @@ def create_primary_pinning_file():
   Returns the filename of the created file.
   """
 
-  fobj = open(demo.DEMO_PRIMARY_PINNING_FNAME, 'r')
-  pinnings = json.load(fobj)
-  fobj.close()
+  with open(demo.DEMO_PRIMARY_PINNING_FNAME, 'r') as fobj:
+    pinnings = json.load(fobj)
 
   fname_to_create = os.path.join(
       demo.DEMO_DIR, 'pinned.json_primary_' + demo.get_random_string(5))

--- a/demo/demo_primary.py
+++ b/demo/demo_primary.py
@@ -209,7 +209,9 @@ def create_primary_pinning_file():
   Returns the filename of the created file.
   """
 
-  pinnings = json.load(open(demo.DEMO_PRIMARY_PINNING_FNAME, 'r'))
+  fobj = open(demo.DEMO_PRIMARY_PINNING_FNAME, 'r')
+  pinnings = json.load(fobj)
+  fobj.close()
 
   fname_to_create = os.path.join(
       demo.DEMO_DIR, 'pinned.json_primary_' + demo.get_random_string(5))

--- a/uptane/common.py
+++ b/uptane/common.py
@@ -475,9 +475,8 @@ def create_directory_structure_for_client(
       pinning_fname, #os.path.join(WORKING_DIR, 'pinned.json'),
       os.path.join(client_dir, 'metadata', 'pinned.json'))
 
-  fobj = open(pinning_fname)
-  pinnings = json.load(fobj)
-  fobj.close()
+  with open(pinning_fname) as fobj:
+    pinnings = json.load(fobj)
 
   for repo_name in pinnings['repositories']:
     os.makedirs(os.path.join(client_dir, 'metadata', repo_name, 'current'))

--- a/uptane/common.py
+++ b/uptane/common.py
@@ -475,7 +475,9 @@ def create_directory_structure_for_client(
       pinning_fname, #os.path.join(WORKING_DIR, 'pinned.json'),
       os.path.join(client_dir, 'metadata', 'pinned.json'))
 
-  pinnings = json.load(open(pinning_fname, 'r'))
+  fobj = open(pinning_fname)
+  pinnings = json.load(fobj)
+  fobj.close()
 
   for repo_name in pinnings['repositories']:
     os.makedirs(os.path.join(client_dir, 'metadata', repo_name, 'current'))


### PR DESCRIPTION
I ran into warnings about files not being closed at these lines,
which used to say `json.load(open(<fname>, 'r'))`.

At first, I thought that would have resulted in the file being
closed when the variable left scope, but, in retrospect, the file
object was returned to json.load, which would not have closed it
on its own.

This PR fixes that by manually opening and closing the file.

**Question:
Is this the best Pythonic way to do this?**