### PR TITLE
Add more tests for inventorydb funcs during vehicle/ECU registration tests

### DIFF
--- a/tests/test_director.py
+++ b/tests/test_director.py
@@ -747,6 +747,35 @@ class TestDirector(unittest.TestCase):
 
 
 
+  def test_60_register_vehicle(self):
+    """Tests inventorydb.register_vehicle()"""
+
+    vin = 'democar2'
+
+    # Make sure the vehicle is not known before the test.
+    with self.assertRaises(uptane.UnknownVehicle):
+      inventory.check_vin_registered(vin)
+    self.assertNotIn(vin, inventory.primary_ecus_by_vin)
+
+
+    inventory.register_vehicle(vin, 'tv_primary')
+
+    # Make sure the registration worked.
+    inventory.check_vin_registered(vin)
+    self.assertEqual('tv_primary', inventory.primary_ecus_by_vin[vin])
+
+    # Expect re-registering WITHOUT overwrite on to fail.
+    with self.assertRaises(uptane.Spoofing):
+      inventory.register_vehicle(vin, 'other_ecu', overwrite=False)
+    self.assertEqual('tv_primary', inventory.primary_ecus_by_vin[vin])
+
+    # Expect re-registering with overwrite to succeed.
+    inventory.register_vehicle(vin, 'tv_primary2', overwrite=True)
+    self.assertEqual('tv_primary2', inventory.primary_ecus_by_vin[vin])
+
+
+
+
 
 # Run unit test.
 if __name__ == '__main__':

--- a/tests/test_director.py
+++ b/tests/test_director.py
@@ -236,12 +236,6 @@ class TestDirector(unittest.TestCase):
 
     vin = 'democar'
 
-    # Expect no registered ECUs or manifests yet.
-    self.assertFalse(inventory.ecu_public_keys)
-    self.assertFalse(inventory.vehicle_manifests[vin])
-    self.assertFalse(inventory.ecu_manifests)
-    self.assertIsNone(inventory.primary_ecus_by_vin[vin])
-
     primary_serial = 'INFOdemocar'
     secondary_serial = 'TCUdemocar'
 
@@ -258,6 +252,11 @@ class TestDirector(unittest.TestCase):
         False]                 # is_primary
 
 
+    # Expect no registered ECUs or manifests yet.
+    self.assertFalse(inventory.ecu_public_keys)
+    self.assertFalse(inventory.vehicle_manifests[vin])
+    self.assertFalse(inventory.ecu_manifests)
+    self.assertIsNone(inventory.primary_ecus_by_vin[vin])
     # Expect these calls to fail due to invalid argument format.
     # Note that none of the arguments should be integers.
     for i in range(4):

--- a/tests/test_director.py
+++ b/tests/test_director.py
@@ -191,6 +191,10 @@ class TestDirector(unittest.TestCase):
     self.assertFalse(inventory.vehicle_manifests)
     self.assertFalse(inventory.ecu_manifests)
 
+    # The VIN should be unknown to the inventory db.
+    with self.assertRaises(uptane.UnknownVehicle):
+      inventory.get_last_vehicle_manifest(vin)
+
     # Register a new vehicle and expect success.
     # This also creates a TUF repository to provide Director metadata for
     # that vehicle.
@@ -200,6 +204,8 @@ class TestDirector(unittest.TestCase):
     # Check resulting contents of inventorydb.
     self.assertIn(vin, inventory.ecus_by_vin)
     self.assertIn(vin, inventory.primary_ecus_by_vin)
+    # The VIN is now known, but there should be no Vehicle Manifests yet
+    self.assertIsNone(inventory.get_last_vehicle_manifest(vin))
 
     # Check resulting contents of Director - specifically, the new repository
     # for the vehicle.

--- a/tests/test_director.py
+++ b/tests/test_director.py
@@ -257,6 +257,21 @@ class TestDirector(unittest.TestCase):
     self.assertFalse(inventory.vehicle_manifests[vin])
     self.assertFalse(inventory.ecu_manifests)
     self.assertIsNone(inventory.primary_ecus_by_vin[vin])
+    with self.assertRaises(uptane.UnknownECU):
+      inventory.get_ecu_public_key(primary_serial)
+    with self.assertRaises(uptane.UnknownECU):
+      inventory.get_ecu_public_key(secondary_serial)
+    with self.assertRaises(uptane.UnknownECU):
+      inventory.get_ecu_manifests(primary_serial)
+    with self.assertRaises(uptane.UnknownECU):
+      inventory.get_ecu_manifests(secondary_serial)
+    with self.assertRaises(uptane.UnknownECU):
+      inventory.get_last_ecu_manifest(primary_serial)
+    with self.assertRaises(uptane.UnknownECU):
+      inventory.get_last_ecu_manifest(secondary_serial)
+
+
+
     # Expect these calls to fail due to invalid argument format.
     # Note that none of the arguments should be integers.
     for i in range(4):
@@ -291,6 +306,12 @@ class TestDirector(unittest.TestCase):
     self.assertIn(primary_serial, inventory.ecu_public_keys)
     self.assertEqual(
         keys_pub['primary'], inventory.ecu_public_keys[primary_serial])
+    self.assertEqual(
+        keys_pub['primary'], inventory.get_ecu_public_key(primary_serial))
+
+    # This should be empty, but should not raise an UnknownECU error now.
+    self.assertFalse(inventory.get_ecu_manifests(primary_serial))
+    self.assertIsNone(inventory.get_last_ecu_manifest(primary_serial))
 
 
     # Register a Secondary.
@@ -304,6 +325,12 @@ class TestDirector(unittest.TestCase):
     self.assertIn(secondary_serial, inventory.ecu_public_keys)
     self.assertEqual(
         keys_pub['secondary'], inventory.ecu_public_keys[secondary_serial])
+    self.assertEqual(
+        keys_pub['secondary'], inventory.get_ecu_public_key(secondary_serial))
+
+    # This should be empty, but should not raise an UnknownECU error now.
+    self.assertFalse(inventory.get_ecu_manifests(secondary_serial))
+    self.assertIsNone(inventory.get_last_ecu_manifest(secondary_serial))
 
 
     # Due to a workaround for the demo website, the next checks will not work,

--- a/uptane/services/inventorydb.py
+++ b/uptane/services/inventorydb.py
@@ -287,6 +287,7 @@ def register_ecu(is_primary, vin, ecu_serial, public_key, overwrite=True):
   uptane.formats.VIN_SCHEMA.check_match(vin)
   uptane.formats.ECU_SERIAL_SCHEMA.check_match(ecu_serial)
   tuf.formats.ANYKEY_SCHEMA.check_match(public_key)
+  tuf.formats.BOOLEAN_SCHEMA.check_match(overwrite)
 
   assert (ecu_serial in ecu_public_keys) == (ecu_serial in ecu_manifests), \
       'Programming error: ECU registration is not consistent.'
@@ -338,6 +339,11 @@ def register_vehicle(vin, primary_ecu_serial=None, overwrite=True):
 
   _check_registration_is_sane(vin)
 
+  if primary_ecu_serial is not None:
+    uptane.formats.ECU_SERIAL_SCHEMA.check_match(primary_ecu_serial)
+
+  tuf.formats.BOOLEAN_SCHEMA.check_match(overwrite)
+
   if not overwrite and vin in ecus_by_vin:
     raise uptane.Spoofing('The given VIN, ' + repr(vin) + ', is already '
         'registered.')
@@ -387,6 +393,8 @@ def _check_registration_is_sane(vin):
 
 
 def check_ecu_registered(ecu_serial):
+
+  uptane.formats.ECU_SERIAL_SCHEMA.check_match(ecu_serial)
 
   if ecu_serial not in ecu_public_keys:
     raise uptane.UnknownECU('The given ECU serial, ' + repr(ecu_serial) +

--- a/uptane/services/inventorydb.py
+++ b/uptane/services/inventorydb.py
@@ -380,11 +380,8 @@ def _check_registration_is_sane(vin):
 
   uptane.formats.VIN_SCHEMA.check_match(vin)
 
-  # # A VIN may be in either none or all three of these dictionaries, and nowhere
-  # # in between, or there is a bug.
-  # if vin in vehicle_manifests != vin in ecus_by_vin or vin in ecus_by_vin != \
-  #     vin in primary_ecus_by_vin:
-
+  # A VIN may be in either none or all three of these dictionaries, and nowhere
+  # in between, or there is a bug.
   assert (vin in vehicle_manifests) == (vin in ecus_by_vin) == (
       vin in primary_ecus_by_vin), 'Programming error.'
 

--- a/uptane/services/inventorydb.py
+++ b/uptane/services/inventorydb.py
@@ -302,15 +302,8 @@ def register_ecu(is_primary, vin, ecu_serial, public_key, overwrite=True):
           'associated with a Primary ECU.')
 
     if ecu_serial in ecu_public_keys:
-
-      # Demo website hack.
-      # TODO: Get rid of this hack and resume raising the Spoofing error.
-      print('The given ECU Serial, ' + repr(ecu_serial) +
+      raise uptane.Spoofing('The given ECU Serial, ' + repr(ecu_serial) +
           ', is already associated with a public key.')
-      return
-
-      # raise uptane.Spoofing('The given ECU Serial, ' + repr(ecu_serial) +
-      #     ', is already associated with a public key.')
 
 
   # Register the VIN if it is unknown.


### PR DESCRIPTION
To improve coverage (and also defend code from future changes), I've added a variety of calls to the inventorydb functions within code that tests the results of vehicle and ECU registration. That test code already checked the values internal to the inventorydb, but didn't always test the associated functions. It now does a better job of that.