### PR TITLE
Exclude redundant format setting error from coverage

### DIFF
--- a/uptane/common.py
+++ b/uptane/common.py
@@ -214,8 +214,10 @@ def sign_over_metadata(
   <Exceptions>
     tuf.FormatError, if 'key_dict' is improperly formatted.
 
-    tuf.UnsupportedLibraryError, if an unsupported or unavailable library is
-    detected.
+    tuf.UnsupportedLibraryError, if an unsupported or unavailable cryptography
+    library is chosen.
+
+    uptane.Error, if the given metadata format is not 'json' or 'der'
 
     TypeError, if 'key_dict' contains an invalid keytype.
 
@@ -247,8 +249,8 @@ def sign_over_metadata(
         {'signed': data, 'signatures': []}, only_signed=True, datatype=datatype)
     data = hashlib.sha256(data).digest()
 
-  else:
-    raise tuf.Error('Unsupported metadata format: ' + repr(metadata_format))
+  else: # pragma no cover
+    raise uptane.Error('Unsupported metadata format: ' + repr(metadata_format))
 
 
   return tuf.keys.create_signature(key_dict, data)
@@ -374,7 +376,7 @@ def verify_signature_over_metadata(
         {'signed': data, 'signatures': []}, only_signed=True, datatype=datatype)
     data = hashlib.sha256(data).digest()
 
-  else:
+  else: # pragma no cover
     raise tuf.Error('Unsupported metadata format: ' + repr(metadata_format))
 
 

--- a/uptane/common.py
+++ b/uptane/common.py
@@ -78,7 +78,8 @@ def sign_signable(
     tuf.FormatError if the provided key is not the correct format or lacks a
     private element.
 
-    uptane.Error if the key type is not in the SUPPORTED_KEY_TYPES for Uptane.
+    uptane.Error if the key type is not in the SUPPORTED_KEY_TYPES for Uptane
+    or tuf.conf.METADATA_FORMAT is neither 'json' nor 'der'.
 
   <Side Effects>
     Adds a signature to the provided signable.
@@ -109,7 +110,7 @@ def sign_signable(
 
     # We should already be guaranteed to have a supported key type due to
     # the ANYKEY_SCHEMA.check_match call above. Defensive programming.
-    if signing_key['keytype'] not in SUPPORTED_KEY_TYPES: # pragma no cover
+    if signing_key['keytype'] not in SUPPORTED_KEY_TYPES: # pragma: no cover
       raise uptane.Error(
           'Unsupported key type: ' + repr(signing_key['keytype']))
 
@@ -249,8 +250,9 @@ def sign_over_metadata(
         {'signed': data, 'signatures': []}, only_signed=True, datatype=datatype)
     data = hashlib.sha256(data).digest()
 
-  else: # pragma no cover
-    raise uptane.Error('Unsupported metadata format: ' + repr(metadata_format))
+  else: # pragma: no cover
+    raise uptane.Error('Unsupported metadata format: ' + repr(metadata_format) +
+        '; the supported formats are: "der" and "json".')
 
 
   return tuf.keys.create_signature(key_dict, data)
@@ -351,6 +353,8 @@ def verify_signature_over_metadata(
     tuf.UnknownMethodError.  Raised if the signing method used by
     'signature' is not one supported.
 
+    uptane.Error, if tuf.conf.METADATA_FORMAT is neither 'json' nor 'der'.
+
   <Side Effects>
     The cryptography library specified in 'tuf.conf' is called to do the actual
     verification. When in 'der' mode, argument data is converted into ASN.1/DER
@@ -376,8 +380,9 @@ def verify_signature_over_metadata(
         {'signed': data, 'signatures': []}, only_signed=True, datatype=datatype)
     data = hashlib.sha256(data).digest()
 
-  else: # pragma no cover
-    raise tuf.Error('Unsupported metadata format: ' + repr(metadata_format))
+  else: # pragma: no cover
+    raise uptane.Error('Unsupported metadata format: ' + repr(metadata_format) +
+        '; the supported formats are: "der" and "json".')
 
 
   return tuf.keys.verify_signature(key_dict, signature, data)

--- a/uptane/common.py
+++ b/uptane/common.py
@@ -109,7 +109,7 @@ def sign_signable(
 
     # We should already be guaranteed to have a supported key type due to
     # the ANYKEY_SCHEMA.check_match call above. Defensive programming.
-    if signing_key['keytype'] not in SUPPORTED_KEY_TYPES:
+    if signing_key['keytype'] not in SUPPORTED_KEY_TYPES: # pragma no cover
       raise uptane.Error(
           'Unsupported key type: ' + repr(signing_key['keytype']))
 


### PR DESCRIPTION
I probably don't need the check for an unsupported format (not 'json' or 'der') in common.sign_over_metadata; it's redundant at this depth in the code, and should be addressed within the called function in the TUF fork instead, but there's a tiny chance it'll spare someone some dev time.... The redundant check doesn't need to be hit in code coverage - even getting there with testing would require a very artificial procedure (set the format to something supported, then later switch it to something unsupported).

So I'm adding `#pragma no cover` to the error.

I'm doing the same for another spot in uptane.common, where a redundant check is performed on the key type of a key. Because the ANYKEY_SCHEMA is *defined* so that only supported keys can even be passed this far into the stack, it is neither currently possible to reach this point with an unsupported key type, nor likely to reach this point with an unsupported key type, nor practical to test reaching this point. Nonetheless, I'm leaving the condition in the code to guard against future changes.