### PR TITLE
Removes implicit VIN registration from ECU registration

### DIFF
--- a/uptane/services/inventorydb.py
+++ b/uptane/services/inventorydb.py
@@ -312,12 +312,9 @@ def register_ecu(is_primary, vin, ecu_serial, public_key, overwrite=True):
       # raise uptane.Spoofing('The given ECU Serial, ' + repr(ecu_serial) +
       #     ', is already associated with a public key.')
 
-
-  # Register the VIN if it is unknown.
-  # No VIN should ever be in only one or the other of ecus_by_vin or
-  # vehicle_manifests, or there is a bug.
-  if vin not in ecus_by_vin:
-    register_vehicle(vin, overwrite=overwrite)
+  # It is expected that the vehicle to which this ECU belongs is already
+  # registered.
+  check_vin_registered(vin)
 
 
   # Associate the ECU with the vehicle.


### PR DESCRIPTION
A vehicle should already be registered before one attempts to register an ECU on it. Implicit vehicle registration is not used and not required.

inventorydb.register_ecu_serial() was written to automatically register a VIN if it was given an unknown VIN. This could lead to mistakes, was unused, and is not necessary, so I'm removing it here. If you try to directly use inventorydb to register an ECU on an unknown vehicle, an error is now correctly raised (uptane.UnknownVehicle).