### PR TITLE
Remove print() and isolate demo code fragments in reference implementation

### DIFF
--- a/demo/demo_director.py
+++ b/demo/demo_director.py
@@ -54,7 +54,11 @@ from six.moves import xmlrpc_server # for the director services interface
 import atexit # to kill server process on exit()
 
 
-# Provided for consistency; used only by demo_primary currently.
+# Tell the reference implementation that we're in demo mode.
+# (Provided for consistency.) Currently, primary.py in the reference
+# implementation uses this to display banners for defenses that would otherwise
+# be hard to notice. No other reference implementation code (secondary.py,
+# director.py, etc.) currently uses this setting, but it could.
 uptane.DEMO_MODE = True
 
 

--- a/demo/demo_director.py
+++ b/demo/demo_director.py
@@ -53,6 +53,11 @@ from six.moves import xmlrpc_server # for the director services interface
 
 import atexit # to kill server process on exit()
 
+
+# Provided for consistency; used only by demo_primary currently.
+uptane.DEMO_MODE = True
+
+
 KNOWN_VINS = ['111', '112', '113', 'democar']
 
 # Dynamic global objects

--- a/demo/demo_image_repo.py
+++ b/demo/demo_image_repo.py
@@ -40,7 +40,11 @@ from six.moves import xmlrpc_server # for the director services interface
 import atexit # to kill server process on exit()
 
 
-# Provided for consistency; used only by demo_primary currently.
+# Tell the reference implementation that we're in demo mode.
+# (Provided for consistency.) Currently, primary.py in the reference
+# implementation uses this to display banners for defenses that would otherwise
+# be hard to notice. No other reference implementation code (secondary.py,
+# director.py, etc.) currently uses this setting, but it could.
 uptane.DEMO_MODE = True
 
 

--- a/demo/demo_image_repo.py
+++ b/demo/demo_image_repo.py
@@ -39,6 +39,11 @@ from six.moves import xmlrpc_server # for the director services interface
 
 import atexit # to kill server process on exit()
 
+
+# Provided for consistency; used only by demo_primary currently.
+uptane.DEMO_MODE = True
+
+
 repo = None
 server_process = None
 xmlrpc_service_thread = None

--- a/demo/demo_primary.py
+++ b/demo/demo_primary.py
@@ -52,6 +52,9 @@ LIBUPTANE_LIBRARY_FNAME = os.path.join(
 
 
 
+# When True, the reference implementation's primary.py code displays banners
+# when firmware images are rejected, to make the successful defense visible.
+uptane.DEMO_MODE = True
 
 
 # Globals

--- a/demo/demo_primary.py
+++ b/demo/demo_primary.py
@@ -52,8 +52,12 @@ LIBUPTANE_LIBRARY_FNAME = os.path.join(
 
 
 
+# Tell the reference implementation that we're in demo mode:
 # When True, the reference implementation's primary.py code displays banners
-# when firmware images are rejected, to make the successful defense visible.
+# when firmware images are rejected during primary_update_cycle, to make the
+# successful defense visible during a demonstration. (Otherwise, the rejection
+# would be hard to notice while the primary would just proceed to the next
+# image.)
 uptane.DEMO_MODE = True
 
 

--- a/demo/demo_secondary.py
+++ b/demo/demo_secondary.py
@@ -19,8 +19,6 @@ ds.submit_ecu_manifest_to_primary() # optionally takes different signed manifest
         nonce,
         manifest)
 
-
-
 """
 from __future__ import print_function
 from __future__ import unicode_literals
@@ -45,6 +43,11 @@ import json # for customizing the Secondary's pinnings file.
 import canonicaljson
 
 from six.moves import xmlrpc_client
+
+
+# Provided for consistency; used only by demo_primary currently.
+uptane.DEMO_MODE = True
+
 
 # Globals
 CLIENT_DIRECTORY_PREFIX = 'temp_secondary' # name for this secondary's directory

--- a/demo/demo_secondary.py
+++ b/demo/demo_secondary.py
@@ -45,7 +45,11 @@ import canonicaljson
 from six.moves import xmlrpc_client
 
 
-# Provided for consistency; used only by demo_primary currently.
+# Tell the reference implementation that we're in demo mode.
+# (Provided for consistency.) Currently, primary.py in the reference
+# implementation uses this to display banners for defenses that would otherwise
+# be hard to notice. No other reference implementation code (secondary.py,
+# director.py, etc.) currently uses this setting, but it could.
 uptane.DEMO_MODE = True
 
 

--- a/demo/demo_timeserver.py
+++ b/demo/demo_timeserver.py
@@ -33,6 +33,10 @@ import uptane.services.timeserver as timeserver
 import uptane.encoding.asn1_codec as asn1_codec
 import hashlib
 
+# Provided for consistency; used only by demo_primary currently.
+uptane.DEMO_MODE = True
+
+
 
 # Restrict director requests to a particular path.
 # Must specify RPC2 here for the XML-RPC interface to work.

--- a/demo/demo_timeserver.py
+++ b/demo/demo_timeserver.py
@@ -33,7 +33,11 @@ import uptane.services.timeserver as timeserver
 import uptane.encoding.asn1_codec as asn1_codec
 import hashlib
 
-# Provided for consistency; used only by demo_primary currently.
+# Tell the reference implementation that we're in demo mode.
+# (Provided for consistency.) Currently, primary.py in the reference
+# implementation uses this to display banners for defenses that would otherwise
+# be hard to notice. No other reference implementation code (secondary.py,
+# director.py, etc.) currently uses this setting, but it could.
 uptane.DEMO_MODE = True
 
 

--- a/uptane/__init__.py
+++ b/uptane/__init__.py
@@ -21,6 +21,10 @@ import os # for getcwd only
 from six.moves import getcwd
 WORKING_DIR = getcwd()
 
+# When True, the reference implementation's primary.py code displays banners
+# when firmware images are rejected, to make the successful defense visible.
+DEMO_MODE = False
+
 ### Exceptions
 class Error(Exception):
   """

--- a/uptane/clients/primary.py
+++ b/uptane/clients/primary.py
@@ -40,8 +40,11 @@ import uptane.encoding.asn1_codec as asn1_codec
 
 from uptane import GREEN, RED, YELLOW, ENDCOLORS
 
-# The following import is a temporary measure to facilitate demonstration.
-# It does not ultimately belong here in the reference implementation.
+# The following two imports are only used for the Uptane demonstration, where
+# they enable delays and the display of splash banners indicating metadata
+# rejection during sequential metadata checks. These should be pulled out of
+# the reference implementation when possible.
+import time
 from demo.uptane_banners import *
 
 
@@ -536,7 +539,6 @@ class Primary(object): # Consider inheriting from Secondary and refactoring.
               text='The Director has instructed us to download a file that does '
               ' does not exactly match the Image Repository metadata. '
               'File: ' + repr(target_filepath), sound=TADA)
-          import time
           time.sleep(3)
 
 
@@ -637,7 +639,6 @@ class Primary(object): # Consider inheriting from Secondary and refactoring.
               text='No image was found that exactly matches the signed metadata '
               'from the Director and Image Repositories. Not keeping '
               'untrustworthy files. ' + repr(target_filepath), sound=TADA)
-          import time
           time.sleep(3)
 
 

--- a/uptane/services/timeserver.py
+++ b/uptane/services/timeserver.py
@@ -21,9 +21,6 @@ try:
 except ImportError:
  uptane.logger.error('pyasn1 library not found. Proceeding using JSON only.')
 else:
- #import uptane.ber_encoder as ber_encoder
- # TODO: Add the modules necessary to handle timeserver attestation ASN1
- # conversion to Uptane.
  PYASN1_EXISTS = True
 
 import time

--- a/uptane/services/timeserver.py
+++ b/uptane/services/timeserver.py
@@ -19,7 +19,7 @@ PYASN1_EXISTS = False
 try:
  import pyasn1.type
 except ImportError:
- print('Minor: pyasn1 library not found. Proceeding using JSON only.')
+ uptane.logger.error('pyasn1 library not found. Proceeding using JSON only.')
 else:
  #import uptane.ber_encoder as ber_encoder
  # TODO: Add the modules necessary to handle timeserver attestation ASN1


### PR DESCRIPTION
This PR addresses two related issues: `print()` and demo code in the reference implementation. In particular:
1. It strips some print() statements that lingered in two modules in the Reference Implementation and replaces them with logging commands (`logger.debug()`, `logger.info()`, `logger.warn()`, `logger.error()`). Print statements are not generally appropriate in the Reference Implementation.
2. It isolates two pieces of demo code that sit inside the Reference Implementation (in primary.py) because of limitations in the workflow when it comes to notifying viewers of the demo about exactly what's going on (When a file is rejected by the Primary, the Primary normally moves on to the next image without much fanfare). This is done by adding a variable to uptane/__init__.py, DEMO_MODE, which is set to False by default and set to True by the demo component modules (`demo_primary.py` etc). The Primary's DEFENDED banners displaying will only occur in DEMO_MODE.

More logging should be added in the future, but that is outside of the scope of this PR.
