### PR TITLE
Raise UnknownVehicle, not Error, when Primary sees unknown VIN

### DIFF
--- a/tests/test_primary.py
+++ b/tests/test_primary.py
@@ -281,8 +281,9 @@ class TestPrimary(unittest.TestCase):
           "ecu_serial": "ecu11111",
           "attacks_detected": ""}}
 
-    # Try using the wrong vin.
-    with self.assertRaises(uptane.Error):
+    # Try using a VIN that is not the Primary's VIN (ECU Manifest apparently
+    # from another car!)
+    with self.assertRaises(uptane.UnknownVehicle):
       TestPrimary.instance.register_ecu_manifest(
           vin='13105941', # unexpected VIN
           ecu_serial='ecu11111', nonce=nonce,

--- a/uptane/clients/primary.py
+++ b/uptane/clients/primary.py
@@ -952,8 +952,8 @@ class Primary(object): # Consider inheriting from Secondary and refactoring.
     tuf.formats.BOOLEAN_SCHEMA.check_match(force_pydict)
 
     if vin != self.vin:
-      raise uptane.Error('Received an ECU Manifest supposedly hailing from a '
-          'different vehicle....')
+      raise uptane.UnknownVehicle('Received an ECU Manifest supposedly hailing '
+          'from a different vehicle....')
 
     if tuf.conf.METADATA_FORMAT == 'der' and not force_pydict:
       # If we're working with ASN.1/DER, convert it into the format specified in


### PR DESCRIPTION
During processing of ECU Manifests from Secondaries by the Primary, uptane.Error was raised instead of uptane.UnknownVehicle when a VIN provided to the Primary was unknown (i.e. not the particular VIN of the vehicle in which the Primary rests).

This is corrected here (uptane.UnknownVehicle is raised) and testing is corrected accordingly.