### PR TITLE
Minor tweaks to primary.py: docstring, arg validation, removing unused code

### DIFF
--- a/tests/test_primary.py
+++ b/tests/test_primary.py
@@ -202,6 +202,16 @@ class TestPrimary(unittest.TestCase):
           timeserver_public_key=TestPrimary.initial_time, # INVALID
           my_secondaries=[])
 
+    # Invalid format for Director Repository name
+    with self.assertRaises(tuf.FormatError):
+      primary.Primary(
+          full_client_dir=TEMP_CLIENT_DIR,
+          director_repo_name=5, #INVALID
+          vin=vin,
+          ecu_serial=primary_ecu_serial,
+          primary_key=TestPrimary.ecu_key, time=TestPrimary.initial_time,
+          timeserver_public_key = TestPrimary.key_timeserver_pub,
+          my_secondaries=[])
 
     # Try creating a Primary, expecting it to work.
     # Initializes a Primary ECU, making a client directory and copying the root

--- a/uptane/clients/primary.py
+++ b/uptane/clients/primary.py
@@ -263,6 +263,7 @@ class Primary(object): # Consider inheriting from Secondary and refactoring.
 
     # Check arguments:
     tuf.formats.PATH_SCHEMA.check_match(full_client_dir)
+    tuf.formats.REPOSITORY_NAME_SCHEMA.check_match(director_repo_name)
     tuf.formats.ISO8601_DATETIME_SCHEMA.check_match(time)
     uptane.formats.VIN_SCHEMA.check_match(vin)
     uptane.formats.ECU_SERIAL_SCHEMA.check_match(ecu_serial)

--- a/uptane/clients/primary.py
+++ b/uptane/clients/primary.py
@@ -597,14 +597,6 @@ class Primary(object): # Consider inheriting from Secondary and refactoring.
       full_fname = os.path.join(full_targets_directory, filepath)
       enforce_jail(filepath, full_targets_directory)
 
-      # TODO: Remove this. It's here for convenience during dev & testing.
-      # Considerations on the ground by implementers / users of the reference
-      # implementation will decide what to do with target files after they've
-      # been used.
-      # Delete existing targets.
-      if os.path.exists(full_fname):
-        os.remove(full_fname)
-
       # Download each target.
       # Now that we have fileinfo for all targets listed by both the Director and
       # the Image Repository -- which should include file2.txt in this test --

--- a/uptane/clients/primary.py
+++ b/uptane/clients/primary.py
@@ -960,16 +960,22 @@ class Primary(object): # Consider inheriting from Secondary and refactoring.
       signed_ecu_manifest
           The ECU Manifest a Secondary is submitting.
 
-      force_pydict (optional, default False)
-          When True, indicates that signed_ecu_manifest is a JSON-compatible
-          Python dictionary, the internal representation of an ECU Manifest,
-          conformant with uptane.formats.SIGNABLE_ECU_VERSION_MANIFEST_SCHEMA,
-          just as if tuf.conf.METADATA_FORMAT were set to json'. By default
-          (False), the expected format of signed_ecu_manifest is based on
-          tuf.conf.METADATA_FORMAT, so signed_ecu_manifest is expected to
-          conform to uptane.formats.DER_DATA_SCHEMA, which decodes to data
-          conformant with uptane.encoding.asn1_definitions.ECUVersionManifest
+          The expected format that signed_ecu_manifest should conform to is
+          based on the value of tuf.conf.METADATA_FORMAT:
 
+            if 'json': uptane.formats.SIGNABLE_ECU_VERSION_MANIFEST_SCHEMA,
+                       a JSON-compatible Python dictionary, the internal
+                       repreentation of an ECU Manifest
+
+            if 'der':  uptane.formats.DER_DATA_SCHEMA encoding data conforming
+                       to ECUVersionManifest specified in file ECUModule.asn1
+                       (and the Uptane Implementation Specification)
+
+          See force_pydict.
+
+      force_pydict (optional, default False)
+          When True, the function treats signed_ecu_manifest as if the value of
+          tuf.conf.METADATA_FORMAT is set to 'json'. See signed_ecu_manifest.
 
     <Exceptions>
 
@@ -982,6 +988,9 @@ class Primary(object): # Consider inheriting from Secondary and refactoring.
 
       uptane.UnknownVehicle
           if the VIN argument is not the same as this primary's VIN
+
+      tuf.FormatError
+          if any of the arguments are not in the expected formats.
 
     <Returns>
       None

--- a/uptane/clients/primary.py
+++ b/uptane/clients/primary.py
@@ -994,19 +994,26 @@ class Primary(object): # Consider inheriting from Secondary and refactoring.
     # check arg format and that serial is registered
     self._check_ecu_serial(ecu_serial)
     tuf.formats.BOOLEAN_SCHEMA.check_match(force_pydict)
+    uptane.formats.VIN_SCHEMA.check_match(vin)
+    uptane.formats.NONCE_SCHEMA.check_match(nonce)
+
 
     if vin != self.vin:
       raise uptane.Error('Received an ECU Manifest supposedly hailing from a '
           'different vehicle....')
 
     if tuf.conf.METADATA_FORMAT == 'der' and not force_pydict:
+      uptane.formats.DER_DATA_SCHEMA.check_match(signed_ecu_manifest)
       # If we're working with ASN.1/DER, convert it into the format specified in
       # uptane.formats.SIGNABLE_ECU_VERSION_MANIFEST_SCHEMA.
       signed_ecu_manifest = asn1_codec.convert_signed_der_to_dersigned_json(
           signed_ecu_manifest, datatype='ecu_manifest')
 
     # Else, we're working with standard Python dictionaries and no conversion
-    # is necessary.
+    # is necessary, but we'll still validate the signed_ecu_manifest argument.
+    else:
+      uptane.formats.SIGNABLE_ECU_VERSION_MANIFEST_SCHEMA.check_match(
+          signed_ecu_manifest)
 
     if ecu_serial != signed_ecu_manifest['signed']['ecu_serial']:
       # TODO: Choose an exception class.


### PR DESCRIPTION
This is a small collection of a few minor adjustments to the `primary.py` module in the Reference Implementation:

- The addition/improvement of a docstring for `primary.register_ecu_manifest`
- The addition of a minor argument check that was missing from `primary.__init__()` (and the addition of a corresponding test)
- The removal of some commented-out code in `primary.py`

You may notice that the docstring indicates that `uptane.UnknownVehicle` is raised if the Primary doesn't know the VIN provided in the submission of the ECU Manifest, even though code on this branch still incorrectly raises `uptane.Error` in that situation. This is corrected in another PR, #135. They will be merged together. This seemed better than going to the effort of backtracking and adding commits on both sides.