### PR TITLE
Clarify difference between Partial and Full verification

### DIFF
--- a/demo/demo_director.py
+++ b/demo/demo_director.py
@@ -517,8 +517,6 @@ def undo_sign_with_compromised_keys_attack():
     None.
   """
 
-  global director_service_instance
-
 
   # Re-load the valid keys, so that the repository objects can be updated to
   # reference them and replace the compromised keys set.
@@ -581,8 +579,6 @@ def add_target_to_director(target_fname, filepath_in_repo, vin, ecu_serial):
       Complies with uptane.formats.ECU_SERIAL_SCHEMA
 
   """
-  global director_service_instance
-
   uptane.formats.VIN_SCHEMA.check_match(vin)
   uptane.formats.ECU_SERIAL_SCHEMA.check_match(ecu_serial)
   tuf.formats.RELPATH_SCHEMA.check_match(target_fname)

--- a/demo/demo_primary.py
+++ b/demo/demo_primary.py
@@ -559,21 +559,20 @@ def get_image_for_ecu(ecu_serial):
 
 def get_metadata_for_ecu(ecu_serial, force_partial_verification=False):
   """
-  Send a zip archive of the most recent consistent set of the Primary's client
-  metadata directory, containing the current, consistent metadata from all
-  repositories used.
+  Provides the (updated) metadata a Secondary will need to validate updates.
 
-  If force_partial_verification is True, then even if the request is coming
-  from a client that is not on a CAN interface and configured to communicate
-  with this Primary via CAN, we will still send partial verification data (just
-  the Director's targets.json file).
+  This takes two forms:
+
+  - For Full Verification Secondaries (the norm):
+      Send a zip archive of the most recent consistent set of the Primary's
+      client metadata directory, containing the current, consistent metadata
+      from all repositories used.
+
+  - For Partial Verification Secondaries:
+      Send the Director's Targets role file.
 
   <Exceptions>
-    uptane.Error
-      - if we are set to communicate via CAN interface, but CAN interface is
-        not ready
-
-    ... fill in more
+    uptane.Error if there is no metadata to distribute
   """
   # Ensure serial is correct format & registered
   primary_ecu._check_ecu_serial(ecu_serial)
@@ -581,15 +580,6 @@ def get_metadata_for_ecu(ecu_serial, force_partial_verification=False):
   # The filename of the file to return.
   fname = None
 
-  # TODO: <~> NO: We can't do it this way. The updater's metadata stored in
-  # this fashion is post-validation and without signatures.
-  # I may have to just transfer files. Is there not somewhere where I can grab
-  # the signed metadata from TUF?
-  # See updater.py _update_metadata 2189-2192?
-  # The more I look at this, the more it looks like I just need to copy all
-  # the files....
-  # I'll use zipfile. In Python 2.7.4 and later, it should prevent files from
-  # being created outside of the target extraction directory.
 
 
 


### PR DESCRIPTION
### Purpose of the PR
- Clarifies the difference between Partial and Full verification in Primary, demo Primary, and demo Director code. This mostly revises docstrings, but also simplifies some demo code conditionals.
- In the demo, strips all CAN-related communication code intended for a CAN-based Partial verification Secondary.

These are in the same PR because of overlap, but they're fairly related. I also strip two unneeded global designations, a completely unrelated but miniscule change. :P

### Motivation
Initial motivation for this comes from the fact that this code seemed to be confusing to students. I'm much happier with the clarity of the result, but I'm sure there are related bits I can clarify. As for the CAN contents, less clutter is better, since that wasn't being used.