### PR TITLE
DEMO: Fix XMLRPC bug in Pri<->Sec communication in Python2.7.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ implementation code, divided into these sections:
 
 
 # 0: Installation
-Uptane supports Python2 and Python3. Demonstration code is currently not compatible with Python 2.7.14 in particular due to a change in the xmlrpc library's behavior. As usual for Python, [virtual environments](https://python-docs.readthedocs.io/en/latest/dev/virtualenvs.html) are recommended for development and testing, but not necessary.
+Uptane supports Python2 and Python3. As usual for Python, [virtual environments](https://python-docs.readthedocs.io/en/latest/dev/virtualenvs.html) are recommended for development and testing, but not necessary.
 
 Some development libraries are necessary to install some of Uptane's dependencies. If your system uses apt, the command to install them will be:
 ```shell

--- a/demo/demo_primary.py
+++ b/demo/demo_primary.py
@@ -626,8 +626,7 @@ def listen():
       primary_ecu.register_new_secondary, 'register_new_secondary')
 
   server.register_function(
-      primary_ecu.get_last_timeserver_attestation,
-      'get_last_timeserver_attestation')
+      get_time_attestation_for_ecu, 'get_time_attestation_for_ecu')
 
   # Distributing images this way is not ideal: there is no method here (as
   # there IS in TUF in general) of detecting endless data attacks or slow

--- a/demo/demo_secondary.py
+++ b/demo/demo_secondary.py
@@ -288,7 +288,7 @@ def update_cycle():
     'http://' + str(_primary_host) + ':' + str(_primary_port))
 
   # Download the time attestation from the Primary.
-  time_attestation = pserver.get_last_timeserver_attestation()
+  time_attestation = pserver.get_time_attestation_for_ecu(_ecu_serial)
   if tuf.conf.METADATA_FORMAT == 'der':
     # Binary data transfered via XMLRPC has to be wrapped in an xmlrpc Binary
     # object. The data itself is contained in attribute 'data'.


### PR DESCRIPTION
Fixes Issue #150.

#### Brief Summary:

The demo Primary exposed the wrong function in its XMLRPC interface to retrieve time attestations from the Primary. This resulted in demo code breaking in Python 2.7.14 after some xmlrpc changes that made the xmlrpc library less permissive.


#### Commit summary:

When in DER mode (default), the function exposed in the demo
Primary's XMLRPC interface to return the latest timeserver
attestation for use by the demo Secondary was not correctly
wrapping the DER encoded attestation in an xmlrpc Binary()
object for transmission. This broke the demo Secondary's
ability to receive the timeserver attestation in Python
2.7.14, which came out about two months ago and now ships
with OS X High Sierra (and some Linux distros).

In particular, the direct exposure of a function from the
reference implementation that has no concept of XMLRPC
was swapped out of the XMLRPC interface in favor of a
higher level function in the demo Primary module.