### PR TITLE
Demo services convenience (single shell, better print messages)

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,9 +217,8 @@ the image and metadata on the Image Repository.
 ```
 
 To assign the new image to the ecu 'TCUdemocar' on vehicle 'democar', run
-the following in teh Uptane services window (WINDOW 1):
+the following in the Uptane services window (WINDOW 1):
 ```python
->>> firmware_fname = filepath_in_repo = 'firmware.img'
 >>> vin='democar'; ecu_serial='TCUdemocar'
 >>> dd.add_target_to_director(firmware_fname, filepath_in_repo, vin, ecu_serial)
 >>> dd.write_to_live(vin_to_update=vin)

--- a/demo/demo_timeserver.py
+++ b/demo/demo_timeserver.py
@@ -88,9 +88,9 @@ def listen(use_new_keys=False):
   """
 
   # Set the timeserver's signing key.
-  print('Loading timeserver signing key.')
+  print(LOG_PREFIX + 'Loading timeserver signing key.')
   timeserver.set_timeserver_key(load_timeserver_key(use_new_keys))
-  print('Timeserver signing key loaded.')
+  print(LOG_PREFIX + 'Timeserver signing key loaded.')
 
 
   # Test locally before opening the XMLRPC port.
@@ -112,8 +112,9 @@ def listen(use_new_keys=False):
       get_signed_time_der_wrapper, 'get_signed_time_der')
 
 
-  print('Timeserver will now listen on port ' + str(demo.TIMESERVER_PORT))
   server.serve_forever()
+  print(LOG_PREFIX + 'Timeserver will now listen on port ' +
+      str(demo.TIMESERVER_PORT))
 
 
 

--- a/demo/demo_timeserver.py
+++ b/demo/demo_timeserver.py
@@ -25,6 +25,7 @@ import uptane
 import uptane.common
 import tuf.formats
 
+import threading
 from six.moves import xmlrpc_server
 from six.moves import xmlrpc_client # for Binary data encapsulation
 import uptane.services.timeserver as timeserver
@@ -40,7 +41,9 @@ import hashlib
 # director.py, etc.) currently uses this setting, but it could.
 uptane.DEMO_MODE = True
 
+LOG_PREFIX = uptane.WHITE + 'Timeserver:' + uptane.ENDCOLORS + ' '
 
+timeserver_listener_thread = None
 
 # Restrict director requests to a particular path.
 # Must specify RPC2 here for the XML-RPC interface to work.
@@ -87,6 +90,8 @@ def listen(use_new_keys=False):
    - get_signed_time(nonces)
   """
 
+  global director_service_thread
+
   # Set the timeserver's signing key.
   print(LOG_PREFIX + 'Loading timeserver signing key.')
   timeserver.set_timeserver_key(load_timeserver_key(use_new_keys))
@@ -112,9 +117,12 @@ def listen(use_new_keys=False):
       get_signed_time_der_wrapper, 'get_signed_time_der')
 
 
-  server.serve_forever()
   print(LOG_PREFIX + 'Timeserver will now listen on port ' +
       str(demo.TIMESERVER_PORT))
+
+  director_service_thread = threading.Thread(target=server.serve_forever)
+  director_service_thread.setDaemon(True)
+  director_service_thread.start()
 
 
 

--- a/demo/start_servers.py
+++ b/demo/start_servers.py
@@ -1,0 +1,46 @@
+"""
+start_servers.py
+
+<Purpose>
+  A simple script to start the three cloud-side Uptane servers:
+    the Director (including its per-vehicle repositories)
+    the Image Repository
+    the Timeserver
+
+  To run the demo services in non-interactive mode, run:
+    python start_servers.py
+
+  To run the demo services in interactive mode, run:
+    python -i -c "from demo.start_servers import *; main()"
+
+  In either mode, the demo services will respond to commands sent via XMLRPC.
+
+"""
+import threading
+import demo
+import demo.demo_timeserver as dt
+import demo.demo_director as dd
+import demo.demo_image_repo as di
+from six.moves import xmlrpc_server
+
+
+def main():
+
+  # Start demo Image Repo, including http server and xmlrpc listener (for
+  # webdemo)
+  di.clean_slate()
+
+  # Start demo Director, including http server and xmlrpc listener (for
+  # manifests, registrations, and webdemo)
+  dd.clean_slate()
+
+  # Start demo Timeserver, including xmlrpc listener (for requests from demo
+  # Primary)
+  dt.listen()
+
+
+
+
+
+if __name__ == '__main__':
+  main()

--- a/uptane/__init__.py
+++ b/uptane/__init__.py
@@ -102,8 +102,22 @@ logger.addHandler(console_handler)
 logger.setLevel(logging.DEBUG)
 
 # Colorful printing for the logger for now.
+# Background colors
+RED_BG = '\033[41m'
+GREEN_BG = '\033[42m'
+TEAL_BG = '\033[46m'
+CYAN_BG = '\033[0;106m'
+PLUM_BG = '\033[45m'
+WHITE_BG = '\033[47m'
+
+# Text colors
+BLACK = '\033[30m'
+
+# Combinations
 RED = '\033[41m\033[30m' # black on red
 GREEN = '\033[42m\033[30m' # black on green
 YELLOW = '\033[93m' # yellow on black
+WHITE = '\033[47m\033[30m' # black on white
+
 ENDCOLORS = '\033[0m'
 


### PR DESCRIPTION
### Purpose of the PR:
Running the console demo is a bit burdensome. This PR improves that somewhat by having a single script start the Timeserver, Image Repo, and Director, and run them out of a single window, with high-level messages from each distinguished from each other.

### Summary of Changes:
- demo Image Repo, demo Director, and demo Timeserver now run out of one window in the console demo
- their high-level messages are prefaced with a color-coded label
- the demo instructions (README.md) were adjusted to accommodate these changes
- the timeserver can now run interactively
- the three demo services can also be started with a single script in non-interactive mode (and will still listen for XMLRPC commands)