### PR TITLE
Remove default datatype from JSON/DER conversion functions

### DIFF
--- a/demo/demo_timeserver.py
+++ b/demo/demo_timeserver.py
@@ -165,8 +165,10 @@ def test_demo_timeserver():
 
   # Validate that signature.
   for pydict_again in [
-      asn1_codec.convert_signed_der_to_dersigned_json(der_signed_time),
-      asn1_codec.convert_signed_der_to_dersigned_json(xb_der_signed_time.data)]:
+      asn1_codec.convert_signed_der_to_dersigned_json(
+          der_signed_time, datatype='time_attestation'),
+      asn1_codec.convert_signed_der_to_dersigned_json(
+          xb_der_signed_time.data, datatype='time_attestation')]:
 
     assert uptane.common.verify_signature_over_metadata(
         timeserver_key_pub,

--- a/demo/demo_timeserver.py
+++ b/demo/demo_timeserver.py
@@ -34,6 +34,8 @@ import uptane.services.timeserver as timeserver
 import uptane.encoding.asn1_codec as asn1_codec
 import hashlib
 
+from uptane.encoding.asn1_codec import DATATYPE_TIME_ATTESTATION
+
 # Tell the reference implementation that we're in demo mode.
 # (Provided for consistency.) Currently, primary.py in the reference
 # implementation uses this to display banners for defenses that would otherwise
@@ -147,7 +149,7 @@ def test_demo_timeserver():
       timeserver_key_pub,
       signed_time['signatures'][0],
       signed_time['signed'],
-      datatype='time_attestation',
+      DATATYPE_TIME_ATTESTATION,
       metadata_format='json'
       ), 'Demo Timeserver self-test fail: unable to verify signature over JSON.'
 
@@ -166,15 +168,15 @@ def test_demo_timeserver():
   # Validate that signature.
   for pydict_again in [
       asn1_codec.convert_signed_der_to_dersigned_json(
-          der_signed_time, datatype='time_attestation'),
+          der_signed_time, DATATYPE_TIME_ATTESTATION),
       asn1_codec.convert_signed_der_to_dersigned_json(
-          xb_der_signed_time.data, datatype='time_attestation')]:
+          xb_der_signed_time.data, DATATYPE_TIME_ATTESTATION)]:
 
     assert uptane.common.verify_signature_over_metadata(
         timeserver_key_pub,
         pydict_again['signatures'][0],
         pydict_again['signed'],
-        datatype='time_attestation',
+        DATATYPE_TIME_ATTESTATION,
         metadata_format='der'
         ), 'Demo Timeserver self-test fail: unable to verify signature over DER'
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -25,6 +25,10 @@ import tuf.conf
 import uptane.common as common
 import uptane.encoding.asn1_codec as asn1_codec
 
+from uptane.encoding.asn1_codec import DATATYPE_TIME_ATTESTATION
+from uptane.encoding.asn1_codec import DATATYPE_ECU_MANIFEST
+from uptane.encoding.asn1_codec import DATATYPE_VEHICLE_MANIFEST
+
 import demo # for generate_key, import_public_key, import_private_key
 
 # The public and private keys to use during testing, including the Director
@@ -108,17 +112,17 @@ class TestCommon(unittest.TestCase):
       sample_time_attestation = \
           asn1_codec.convert_signed_der_to_dersigned_json(open(os.path.join(
           SAMPLES_DIR, 'sample_timeserver_attestation.der'), 'rb').read(),
-          datatype='time_attestation')
+          DATATYPE_TIME_ATTESTATION)
 
       sample_vehicle_manifest = \
           asn1_codec.convert_signed_der_to_dersigned_json(open(os.path.join(
           SAMPLES_DIR, 'sample_vehicle_version_manifest_democar.der'),
-          'rb').read(), datatype='vehicle_manifest')
+          'rb').read(), DATATYPE_VEHICLE_MANIFEST)
 
       sample_ecu_manifest = \
           asn1_codec.convert_signed_der_to_dersigned_json(open(os.path.join(
           SAMPLES_DIR, 'sample_ecu_manifest_TCUdemocar.der'), 'rb').read(),
-          datatype='ecu_manifest')
+          DATATYPE_ECU_MANIFEST)
 
       fresh_time_attestation = tuf.formats.make_signable(
           sample_time_attestation['signed'])
@@ -156,39 +160,39 @@ class TestCommon(unittest.TestCase):
 
     # Time Attestation
     sig_alone = common.sign_over_metadata(keys_pri['timeserver'],
-        fresh_time_attestation['signed'], datatype='time_attestation')
+        fresh_time_attestation['signed'], DATATYPE_TIME_ATTESTATION)
     common.sign_signable(fresh_time_attestation, [keys_pri['timeserver']],
-        datatype='time_attestation')
+        DATATYPE_TIME_ATTESTATION)
     self.assertEqual(sig_alone, fresh_time_attestation['signatures'][0])
     self.assertEqual(fresh_time_attestation['signatures'],
         sample_time_attestation['signatures'])
     self.assertTrue(common.verify_signature_over_metadata(
         keys_pub['timeserver'], fresh_time_attestation['signatures'][0],
-        fresh_time_attestation['signed'], datatype='time_attestation'))
+        fresh_time_attestation['signed'], DATATYPE_TIME_ATTESTATION))
 
     # Vehicle Manifest
     sig_alone = common.sign_over_metadata(keys_pri['primary'],
-        fresh_vehicle_manifest['signed'], datatype='vehicle_manifest')
+        fresh_vehicle_manifest['signed'], DATATYPE_VEHICLE_MANIFEST)
     common.sign_signable(fresh_vehicle_manifest, [keys_pri['primary']],
-        datatype='vehicle_manifest')
+        DATATYPE_VEHICLE_MANIFEST)
     self.assertEqual(sig_alone, fresh_vehicle_manifest['signatures'][0])
     self.assertEqual(fresh_vehicle_manifest['signatures'],
         sample_vehicle_manifest['signatures'])
     self.assertTrue(common.verify_signature_over_metadata(
         keys_pub['primary'], fresh_vehicle_manifest['signatures'][0],
-        fresh_vehicle_manifest['signed'], datatype='vehicle_manifest'))
+        fresh_vehicle_manifest['signed'], DATATYPE_VEHICLE_MANIFEST))
 
     # ECU Manifest
     sig_alone = common.sign_over_metadata(keys_pri['secondary'],
-        fresh_ecu_manifest['signed'], datatype='ecu_manifest')
+        fresh_ecu_manifest['signed'], DATATYPE_ECU_MANIFEST)
     common.sign_signable(
-        fresh_ecu_manifest, [keys_pri['secondary']], datatype='ecu_manifest')
+        fresh_ecu_manifest, [keys_pri['secondary']], DATATYPE_ECU_MANIFEST)
     self.assertEqual(sig_alone, fresh_ecu_manifest['signatures'][0])
     self.assertEqual(fresh_ecu_manifest['signatures'],
         sample_ecu_manifest['signatures'])
     self.assertTrue(common.verify_signature_over_metadata(
         keys_pub['secondary'], fresh_ecu_manifest['signatures'][0],
-        fresh_ecu_manifest['signed'], datatype='ecu_manifest'))
+        fresh_ecu_manifest['signed'], DATATYPE_ECU_MANIFEST))
 
 
 
@@ -196,20 +200,20 @@ class TestCommon(unittest.TestCase):
     # twice. Try only with ECU Manifests for brevity. (Shouldn't matter)
     common.sign_signable(
         fresh_ecu_manifest2, [keys_pri['secondary'], keys_pri['secondary']],
-        datatype='ecu_manifest')
+        DATATYPE_ECU_MANIFEST)
     self.assertEqual(1, len(fresh_ecu_manifest2['signatures']))
     self.assertEqual(fresh_ecu_manifest2['signatures'],
         sample_ecu_manifest['signatures'])
     self.assertTrue(common.verify_signature_over_metadata(
         keys_pub['secondary'], fresh_ecu_manifest2['signatures'][0],
-        fresh_ecu_manifest2['signed'], datatype='ecu_manifest'))
+        fresh_ecu_manifest2['signed'], DATATYPE_ECU_MANIFEST))
 
 
 
     # Try signing with two keys.
     common.sign_signable(
         fresh_ecu_manifest3, [keys_pri['secondary'], keys_pri['primary']],
-        datatype='ecu_manifest')
+        DATATYPE_ECU_MANIFEST)
     self.assertEqual(2, len(fresh_ecu_manifest3['signatures']))
     sigs = fresh_ecu_manifest3['signatures']
     if sigs[0]['keyid'] == keys_pri['primary']['keyid']:
@@ -230,9 +234,9 @@ class TestCommon(unittest.TestCase):
         sample_ecu_manifest['signatures'][0]['sig'], secondary_sig['sig'])
 
     self.assertTrue(common.verify_signature_over_metadata(keys_pub['secondary'],
-        secondary_sig, sample_ecu_manifest['signed'], datatype='ecu_manifest'))
+        secondary_sig, sample_ecu_manifest['signed'], DATATYPE_ECU_MANIFEST))
     self.assertTrue(common.verify_signature_over_metadata(keys_pub['primary'],
-        primary_sig, sample_ecu_manifest['signed'], datatype='ecu_manifest'))
+        primary_sig, sample_ecu_manifest['signed'], DATATYPE_ECU_MANIFEST))
 
 
 
@@ -241,7 +245,7 @@ class TestCommon(unittest.TestCase):
     # compare it to the original, expecting no change.
     duped_vehicle_manifest = copy.deepcopy(fresh_vehicle_manifest)
     common.sign_signable(duped_vehicle_manifest, [keys_pri['primary']],
-        datatype='vehicle_manifest')
+        DATATYPE_VEHICLE_MANIFEST)
 
     self.assertEqual(
         len(fresh_vehicle_manifest['signatures']),
@@ -259,7 +263,7 @@ class TestCommon(unittest.TestCase):
     # test, so I'll proceed as if we don't know the signature order in this
     # test.
     common.sign_signable(fresh_ecu_manifest, [keys_pri['primary']],
-        datatype='ecu_manifest')
+        DATATYPE_ECU_MANIFEST)
     self.assertEqual(2, len(fresh_ecu_manifest['signatures']))
     sigs = fresh_ecu_manifest['signatures']
     if sigs[0]['keyid'] == keys_pri['primary']['keyid']:
@@ -276,9 +280,9 @@ class TestCommon(unittest.TestCase):
         sample_ecu_manifest['signatures'][0]['sig'], secondary_sig['sig'])
 
     self.assertTrue(common.verify_signature_over_metadata(keys_pub['secondary'],
-        secondary_sig, sample_ecu_manifest['signed'], datatype='ecu_manifest'))
+        secondary_sig, sample_ecu_manifest['signed'], DATATYPE_ECU_MANIFEST))
     self.assertTrue(common.verify_signature_over_metadata(keys_pub['primary'],
-        primary_sig, sample_ecu_manifest['signed'], datatype='ecu_manifest'))
+        primary_sig, sample_ecu_manifest['signed'], DATATYPE_ECU_MANIFEST))
 
     # Paranoid: duplicates should have the same signed element.
     self.assertEqual(
@@ -291,7 +295,7 @@ class TestCommon(unittest.TestCase):
     # tuf.FormatError.
     with self.assertRaises(tuf.FormatError):
       common.sign_signable(fresh_time_attestation2, [keys_pub['secondary']],
-          datatype='time_attestation')
+          DATATYPE_TIME_ATTESTATION)
 
 
     # Consider performing this test. (Not likely to be useful.)
@@ -305,7 +309,7 @@ class TestCommon(unittest.TestCase):
     # key_badtype['keytype'] = 'nonsense_type'
     # with self.assertRaises(uptane.Error):
     #   common.sign_signable(fresh_ecu_manifest4, [key_badtype],
-    #       datatype='ecu_manifest')
+    #       DATATYPE_ECU_MANIFEST)
 
 
 

--- a/tests/test_der_encoder.py
+++ b/tests/test_der_encoder.py
@@ -32,6 +32,10 @@ import time
 import copy
 import shutil
 
+from uptane.encoding.asn1_codec import DATATYPE_TIME_ATTESTATION
+from uptane.encoding.asn1_codec import DATATYPE_ECU_MANIFEST
+from uptane.encoding.asn1_codec import DATATYPE_VEHICLE_MANIFEST
+
 # For temporary convenience
 import demo # for generate_key, import_public_key, import_private_key
 
@@ -226,12 +230,12 @@ class TestASN1(unittest.TestCase):
 
     # Converts it, without re-signing (default for this method).
     der_attestation = asn1_codec.convert_signed_metadata_to_der(
-        signable_attestation, datatype='time_attestation')
+        signable_attestation, DATATYPE_TIME_ATTESTATION)
 
     self.assertTrue(is_valid_nonempty_der(der_attestation))
 
     attestation_again = asn1_codec.convert_signed_der_to_dersigned_json(
-        der_attestation, datatype='time_attestation')
+        der_attestation, DATATYPE_TIME_ATTESTATION)
 
     self.assertEqual(attestation_again, signable_attestation)
 
@@ -344,7 +348,7 @@ class TestASN1(unittest.TestCase):
     # signable_attestation. We produce it here so that we can check it against
     # the result of encoding, resigning, and decoding.
     der_signed = asn1_codec.convert_signed_metadata_to_der(
-        signable_attestation, datatype='time_attestation', only_signed=True)
+        signable_attestation, DATATYPE_TIME_ATTESTATION, only_signed=True)
     der_signed_hash = hashlib.sha256(der_signed).digest()
 
 
@@ -354,7 +358,7 @@ class TestASN1(unittest.TestCase):
     # the hash of the DER encoding of the 'signed' ASN.1 data.
     # This is the final product to be distributed back to a Primary client.
     der_attestation = asn1_codec.convert_signed_metadata_to_der(
-        signable_attestation, datatype='time_attestation',
+        signable_attestation, DATATYPE_TIME_ATTESTATION,
         private_key=timeserver_key, resign=True)
 
 
@@ -362,7 +366,7 @@ class TestASN1(unittest.TestCase):
     # pyasn1 ASN.1, and convert back into Uptane's standard Python dictionary
     # form.
     pydict_again = asn1_codec.convert_signed_der_to_dersigned_json(
-        der_attestation, datatype='time_attestation')
+        der_attestation, DATATYPE_TIME_ATTESTATION)
 
     # Check the extracted signature against the hash we produced earlier.
     self.assertTrue(tuf.keys.verify_signature(
@@ -389,7 +393,7 @@ class TestASN1(unittest.TestCase):
         str('signed'): {str('nonces'): [1],
         str('time'): str('2017-03-08T17:09:56Z')}}
     conversion_tester(
-        signable_attestation, 'time_attestation', self)
+        signable_attestation, DATATYPE_TIME_ATTESTATION, self)
 
 
 
@@ -417,18 +421,18 @@ class TestASN1(unittest.TestCase):
   def test_11_ecu_manifest_der_conversion(self):
 
     conversion_tester(
-        SAMPLE_ECU_MANIFEST_SIGNABLE, 'ecu_manifest', self)
+        SAMPLE_ECU_MANIFEST_SIGNABLE, DATATYPE_ECU_MANIFEST, self)
 
 
     # Redundant tests. The above call should cover all of the following tests.
     der_ecu_manifest = asn1_codec.convert_signed_metadata_to_der(
-        SAMPLE_ECU_MANIFEST_SIGNABLE, datatype='ecu_manifest', only_signed=True)
+        SAMPLE_ECU_MANIFEST_SIGNABLE, DATATYPE_ECU_MANIFEST, only_signed=True)
 
     der_ecu_manifest = asn1_codec.convert_signed_metadata_to_der(
-        SAMPLE_ECU_MANIFEST_SIGNABLE, datatype='ecu_manifest')
+        SAMPLE_ECU_MANIFEST_SIGNABLE, DATATYPE_ECU_MANIFEST)
 
     pydict_ecu_manifest = asn1_codec.convert_signed_der_to_dersigned_json(
-        der_ecu_manifest, datatype='ecu_manifest')
+        der_ecu_manifest, DATATYPE_ECU_MANIFEST)
 
     self.assertEqual(
         pydict_ecu_manifest, SAMPLE_ECU_MANIFEST_SIGNABLE)
@@ -441,7 +445,7 @@ class TestASN1(unittest.TestCase):
     uptane.formats.SIGNABLE_VEHICLE_VERSION_MANIFEST_SCHEMA.check_match(
         SAMPLE_VEHICLE_MANIFEST_SIGNABLE)
     conversion_tester(
-        SAMPLE_VEHICLE_MANIFEST_SIGNABLE, 'vehicle_manifest', self)
+        SAMPLE_VEHICLE_MANIFEST_SIGNABLE, DATATYPE_VEHICLE_MANIFEST, self)
 
 
 
@@ -467,7 +471,7 @@ def conversion_tester(signable_pydict, datatype, cls): # cls: clunky
   # Convert and return only the 'signed' portion, the metadata payload itself,
   # without including any signatures.
   signed_der = asn1_codec.convert_signed_metadata_to_der(
-      signable_pydict, datatype=datatype, only_signed=True)
+      signable_pydict, datatype, only_signed=True)
 
   cls.assertTrue(is_valid_nonempty_der(signed_der))
 
@@ -480,12 +484,12 @@ def conversion_tester(signable_pydict, datatype, cls): # cls: clunky
   # Convert the full signable ('signed' and 'signatures'), maintaining the
   # existing signature in a new format and encoding.
   signable_der = asn1_codec.convert_signed_metadata_to_der(
-      signable_pydict, datatype=datatype)
+      signable_pydict, datatype)
   cls.assertTrue(is_valid_nonempty_der(signable_der))
 
   # Convert it back.
   signable_reverted = asn1_codec.convert_signed_der_to_dersigned_json(
-      signable_der, datatype=datatype)
+      signable_der, datatype)
 
   # Ensure the original is equal to what is converted back.
   cls.assertEqual(signable_pydict, signable_reverted)
@@ -497,13 +501,12 @@ def conversion_tester(signable_pydict, datatype, cls): # cls: clunky
   # original signatures and re-signing over, instead, the hash of the converted,
   # ASN.1/DER 'signed' element.
   resigned_der = asn1_codec.convert_signed_metadata_to_der(
-      signable_pydict, datatype=datatype, resign=True,
-      private_key=test_signing_key)
+      signable_pydict, datatype, resign=True, private_key=test_signing_key)
   cls.assertTrue(is_valid_nonempty_der(resigned_der))
 
   # Convert the re-signed DER manifest back in order to split it up.
   resigned_reverted = asn1_codec.convert_signed_der_to_dersigned_json(
-      resigned_der, datatype=datatype)
+      resigned_der, datatype)
   resigned_signature = resigned_reverted['signatures'][0]
 
   # Check the signature on the re-signed DER manifest:
@@ -511,7 +514,7 @@ def conversion_tester(signable_pydict, datatype, cls): # cls: clunky
       test_signing_key,
       resigned_signature,
       resigned_reverted['signed'],
-      datatype=datatype,
+      datatype,
       metadata_format='der'))
 
   # The signatures will not match, because a new signature was made, but the

--- a/tests/test_der_encoder.py
+++ b/tests/test_der_encoder.py
@@ -226,12 +226,12 @@ class TestASN1(unittest.TestCase):
 
     # Converts it, without re-signing (default for this method).
     der_attestation = asn1_codec.convert_signed_metadata_to_der(
-        signable_attestation)
+        signable_attestation, datatype='time_attestation')
 
     self.assertTrue(is_valid_nonempty_der(der_attestation))
 
     attestation_again = asn1_codec.convert_signed_der_to_dersigned_json(
-        der_attestation)
+        der_attestation, datatype='time_attestation')
 
     self.assertEqual(attestation_again, signable_attestation)
 
@@ -344,7 +344,7 @@ class TestASN1(unittest.TestCase):
     # signable_attestation. We produce it here so that we can check it against
     # the result of encoding, resigning, and decoding.
     der_signed = asn1_codec.convert_signed_metadata_to_der(
-        signable_attestation, only_signed=True)
+        signable_attestation, datatype='time_attestation', only_signed=True)
     der_signed_hash = hashlib.sha256(der_signed).digest()
 
 
@@ -354,14 +354,15 @@ class TestASN1(unittest.TestCase):
     # the hash of the DER encoding of the 'signed' ASN.1 data.
     # This is the final product to be distributed back to a Primary client.
     der_attestation = asn1_codec.convert_signed_metadata_to_der(
-        signable_attestation, private_key=timeserver_key, resign=True)
+        signable_attestation, datatype='time_attestation',
+        private_key=timeserver_key, resign=True)
 
 
     # Now, in order to test the final product, decode it back from DER into
     # pyasn1 ASN.1, and convert back into Uptane's standard Python dictionary
     # form.
     pydict_again = asn1_codec.convert_signed_der_to_dersigned_json(
-        der_attestation)
+        der_attestation, datatype='time_attestation')
 
     # Check the extracted signature against the hash we produced earlier.
     self.assertTrue(tuf.keys.verify_signature(
@@ -421,7 +422,7 @@ class TestASN1(unittest.TestCase):
 
     # Redundant tests. The above call should cover all of the following tests.
     der_ecu_manifest = asn1_codec.convert_signed_metadata_to_der(
-        SAMPLE_ECU_MANIFEST_SIGNABLE, only_signed=True, datatype='ecu_manifest')
+        SAMPLE_ECU_MANIFEST_SIGNABLE, datatype='ecu_manifest', only_signed=True)
 
     der_ecu_manifest = asn1_codec.convert_signed_metadata_to_der(
         SAMPLE_ECU_MANIFEST_SIGNABLE, datatype='ecu_manifest')
@@ -466,7 +467,7 @@ def conversion_tester(signable_pydict, datatype, cls): # cls: clunky
   # Convert and return only the 'signed' portion, the metadata payload itself,
   # without including any signatures.
   signed_der = asn1_codec.convert_signed_metadata_to_der(
-      signable_pydict, only_signed=True, datatype=datatype)
+      signable_pydict, datatype=datatype, only_signed=True)
 
   cls.assertTrue(is_valid_nonempty_der(signed_der))
 
@@ -496,8 +497,8 @@ def conversion_tester(signable_pydict, datatype, cls): # cls: clunky
   # original signatures and re-signing over, instead, the hash of the converted,
   # ASN.1/DER 'signed' element.
   resigned_der = asn1_codec.convert_signed_metadata_to_der(
-      signable_pydict, resign=True, private_key=test_signing_key,
-      datatype=datatype)
+      signable_pydict, datatype=datatype, resign=True,
+      private_key=test_signing_key)
   cls.assertTrue(is_valid_nonempty_der(resigned_der))
 
   # Convert the re-signed DER manifest back in order to split it up.

--- a/tests/test_director.py
+++ b/tests/test_director.py
@@ -27,7 +27,10 @@ import uptane.formats
 import uptane.services.director as director
 import uptane.services.inventorydb as inventory
 # import uptane.common # verify sigs, create client dir structure, convert key
-# import uptane.encoding.asn1_codec as asn1_codec
+
+from uptane.encoding.asn1_codec import DATATYPE_TIME_ATTESTATION
+from uptane.encoding.asn1_codec import DATATYPE_ECU_MANIFEST
+from uptane.encoding.asn1_codec import DATATYPE_VEHICLE_MANIFEST
 
 # For temporary convenience:
 import demo # for generate_key, import_public_key, import_private_key
@@ -383,7 +386,7 @@ class TestDirector(unittest.TestCase):
 
       # Use asn1_codec to convert to a JSON-compatible dictionary.
       sample_manifest = asn1_codec.convert_signed_der_to_dersigned_json(
-          der_data, datatype='ecu_manifest')
+          der_data, DATATYPE_ECU_MANIFEST)
 
     else:
       sample_manifest = tuf.util.load_file(os.path.join('samples',
@@ -590,7 +593,7 @@ class TestDirector(unittest.TestCase):
       # When using DER, we can convert JSON to DER and re-sign with the wrong
       # key to achieve a similar test.
       manifest_bad = asn1_codec.convert_signed_metadata_to_der(
-          manifest_json, resign=True, datatype='vehicle_manifest',
+          manifest_json, DATATYPE_VEHICLE_MANIFEST, resign=True,
           private_key=demo.import_private_key('directortimestamp'))
 
     # Try registering the bad-signature manifest.

--- a/tests/test_primary.py
+++ b/tests/test_primary.py
@@ -570,7 +570,7 @@ class TestPrimary(unittest.TestCase):
     if tuf.conf.METADATA_FORMAT == 'der':
       # Convert this time attestation to the expected ASN.1/DER format.
       time_attestation = asn1_codec.convert_signed_metadata_to_der(
-          original_time_attestation,
+          original_time_attestation, datatype='time_attestation',
           private_key=TestPrimary.key_timeserver_pri, resign=True)
 
 
@@ -635,7 +635,7 @@ class TestPrimary(unittest.TestCase):
     if tuf.conf.METADATA_FORMAT == 'der':
       # Convert this time attestation to the expected ASN.1/DER format.
       time_attestation__wrongnonce = asn1_codec.convert_signed_metadata_to_der(
-          time_attestation__wrongnonce,
+          time_attestation__wrongnonce, datatype='time_attestation',
           private_key=TestPrimary.key_timeserver_pri, resign=True)
 
     with self.assertRaises(uptane.BadTimeAttestation):

--- a/tests/test_primary.py
+++ b/tests/test_primary.py
@@ -31,6 +31,10 @@ import uptane.clients.primary as primary
 import uptane.common # verify sigs, create client dir structure, convert key
 import uptane.encoding.asn1_codec as asn1_codec
 
+from uptane.encoding.asn1_codec import DATATYPE_TIME_ATTESTATION
+from uptane.encoding.asn1_codec import DATATYPE_ECU_MANIFEST
+from uptane.encoding.asn1_codec import DATATYPE_VEHICLE_MANIFEST
+
 # For temporary convenience:
 import demo # for generate_key, import_public_key, import_private_key
 import json
@@ -363,25 +367,25 @@ class TestPrimary(unittest.TestCase):
           'em1_typical_ecu_manifest.der'), 'rb').read()
 
       manifest1_json = asn1_codec.convert_signed_der_to_dersigned_json(
-          manifest1, 'ecu_manifest')
+          manifest1, DATATYPE_ECU_MANIFEST)
 
       manifest2 = open(os.path.join(TEST_DATA_DIR, 'flawed_manifests',
           'em2_unknown_ecu_manifest.der'), 'rb').read()
 
       manifest2_json = asn1_codec.convert_signed_der_to_dersigned_json(
-          manifest2, 'ecu_manifest')
+          manifest2, DATATYPE_ECU_MANIFEST)
 
       manifest3 = open(os.path.join(TEST_DATA_DIR, 'flawed_manifests',
           'em3_ecu_manifest_signed_with_wrong_key.der'), 'rb').read()
 
       manifest3_json = asn1_codec.convert_signed_der_to_dersigned_json(
-          manifest3, 'ecu_manifest')
+          manifest3, DATATYPE_ECU_MANIFEST)
 
       manifest4 = open(os.path.join(TEST_DATA_DIR, 'flawed_manifests',
           'em4_attack_detected_in_ecu_manifest.der'), 'rb').read()
 
       manifest4_json = asn1_codec.convert_signed_der_to_dersigned_json(
-          manifest4, 'ecu_manifest')
+          manifest4, DATATYPE_ECU_MANIFEST)
 
 
     # Register two Secondaries with the Primary.
@@ -570,7 +574,7 @@ class TestPrimary(unittest.TestCase):
     if tuf.conf.METADATA_FORMAT == 'der':
       # Convert this time attestation to the expected ASN.1/DER format.
       time_attestation = asn1_codec.convert_signed_metadata_to_der(
-          original_time_attestation, datatype='time_attestation',
+          original_time_attestation, DATATYPE_TIME_ATTESTATION,
           private_key=TestPrimary.key_timeserver_pri, resign=True)
 
 
@@ -605,7 +609,7 @@ class TestPrimary(unittest.TestCase):
       # Fail to re-sign the DER, so that the signature is over JSON instead,
       # which results in a bad signature.
       time_attestation__badsig = asn1_codec.convert_signed_metadata_to_der(
-          original_time_attestation, resign=False, datatype='time_attestation')
+          original_time_attestation, DATATYPE_TIME_ATTESTATION, resign=False)
 
     else: # 'json' format
       # Rewrite the first 9 digits of the signature ('sig') to something
@@ -635,7 +639,7 @@ class TestPrimary(unittest.TestCase):
     if tuf.conf.METADATA_FORMAT == 'der':
       # Convert this time attestation to the expected ASN.1/DER format.
       time_attestation__wrongnonce = asn1_codec.convert_signed_metadata_to_der(
-          time_attestation__wrongnonce, datatype='time_attestation',
+          time_attestation__wrongnonce, DATATYPE_TIME_ATTESTATION,
           private_key=TestPrimary.key_timeserver_pri, resign=True)
 
     with self.assertRaises(uptane.BadTimeAttestation):
@@ -658,7 +662,7 @@ class TestPrimary(unittest.TestCase):
     if tuf.conf.METADATA_FORMAT == 'der':
       uptane.formats.DER_DATA_SCHEMA.check_match(vehicle_manifest)
       vehicle_manifest = asn1_codec.convert_signed_der_to_dersigned_json(
-          vehicle_manifest, datatype='vehicle_manifest')
+          vehicle_manifest, DATATYPE_VEHICLE_MANIFEST)
 
     # Now it's not in DER format, whether or not it started that way.
     # Check its format and inspect it.
@@ -681,7 +685,7 @@ class TestPrimary(unittest.TestCase):
         TestPrimary.ecu_key,
         vehicle_manifest['signatures'][0], # TODO: Deal with 1-sig assumption?
         vehicle_manifest['signed'],
-        datatype='vehicle_manifest'))
+        DATATYPE_VEHICLE_MANIFEST))
 
 
 

--- a/tests/test_secondary.py
+++ b/tests/test_secondary.py
@@ -31,6 +31,9 @@ import uptane.clients.secondary as secondary
 import uptane.common # verify sigs, create client dir structure, convert key
 import uptane.encoding.asn1_codec as asn1_codec
 
+from uptane.encoding.asn1_codec import DATATYPE_TIME_ATTESTATION
+from uptane.encoding.asn1_codec import DATATYPE_ECU_MANIFEST
+
 # For temporary convenience:
 import demo # for generate_key, import_public_key, import_private_key
 
@@ -480,7 +483,7 @@ class TestSecondary(unittest.TestCase):
     if tuf.conf.METADATA_FORMAT == 'der':
       # Convert this time attestation to the expected ASN.1/DER format.
       time_attestation = asn1_codec.convert_signed_metadata_to_der(
-          original_time_attestation, datatype='time_attestation',
+          original_time_attestation, DATATYPE_TIME_ATTESTATION,
           private_key=TestSecondary.key_timeserver_pri, resign=True)
 
     # If the time_attestation is not deemed valid, an exception will be raised.
@@ -493,7 +496,7 @@ class TestSecondary(unittest.TestCase):
       # Fail to re-sign the DER, so that the signature is over JSON instead,
       # which results in a bad signature.
       time_attestation__badsig = asn1_codec.convert_signed_metadata_to_der(
-          original_time_attestation, resign=False, datatype='time_attestation')
+          original_time_attestation, DATATYPE_TIME_ATTESTATION, resign=False)
 
     else: # 'json' format
       # Rewrite the first 9 digits of the signature ('sig') to something
@@ -523,7 +526,7 @@ class TestSecondary(unittest.TestCase):
     if tuf.conf.METADATA_FORMAT == 'der':
       # Convert this time attestation to the expected ASN.1/DER format.
       time_attestation__wrongnonce = asn1_codec.convert_signed_metadata_to_der(
-          time_attestation__wrongnonce, datatype='time_attestation',
+          time_attestation__wrongnonce, DATATYPE_TIME_ATTESTATION,
           private_key=TestSecondary.key_timeserver_pri, resign=True)
 
     with self.assertRaises(uptane.BadTimeAttestation):
@@ -550,7 +553,7 @@ class TestSecondary(unittest.TestCase):
     if tuf.conf.METADATA_FORMAT == 'der':
       uptane.formats.DER_DATA_SCHEMA.check_match(ecu_manifest)
       ecu_manifest = asn1_codec.convert_signed_der_to_dersigned_json(
-          ecu_manifest, datatype='ecu_manifest')
+          ecu_manifest, DATATYPE_ECU_MANIFEST)
 
     # Now it's not in DER format, whether or not it started that way.
     # Check its format and inspect it.
@@ -570,7 +573,7 @@ class TestSecondary(unittest.TestCase):
         TestSecondary.secondary_ecu_key,
         ecu_manifest['signatures'][0], # TODO: Deal with 1-sig assumption?
         ecu_manifest['signed'],
-        datatype='ecu_manifest'))
+        DATATYPE_ECU_MANIFEST))
 
 
 

--- a/tests/test_secondary.py
+++ b/tests/test_secondary.py
@@ -480,7 +480,7 @@ class TestSecondary(unittest.TestCase):
     if tuf.conf.METADATA_FORMAT == 'der':
       # Convert this time attestation to the expected ASN.1/DER format.
       time_attestation = asn1_codec.convert_signed_metadata_to_der(
-          original_time_attestation,
+          original_time_attestation, datatype='time_attestation',
           private_key=TestSecondary.key_timeserver_pri, resign=True)
 
     # If the time_attestation is not deemed valid, an exception will be raised.
@@ -523,7 +523,7 @@ class TestSecondary(unittest.TestCase):
     if tuf.conf.METADATA_FORMAT == 'der':
       # Convert this time attestation to the expected ASN.1/DER format.
       time_attestation__wrongnonce = asn1_codec.convert_signed_metadata_to_der(
-          time_attestation__wrongnonce,
+          time_attestation__wrongnonce, datatype='time_attestation',
           private_key=TestSecondary.key_timeserver_pri, resign=True)
 
     with self.assertRaises(uptane.BadTimeAttestation):

--- a/uptane/clients/primary.py
+++ b/uptane/clients/primary.py
@@ -38,6 +38,10 @@ import uptane.services.director as director
 import uptane.services.timeserver as timeserver
 import uptane.encoding.asn1_codec as asn1_codec
 
+from uptane.encoding.asn1_codec import DATATYPE_TIME_ATTESTATION
+from uptane.encoding.asn1_codec import DATATYPE_ECU_MANIFEST
+from uptane.encoding.asn1_codec import DATATYPE_VEHICLE_MANIFEST
+
 from uptane import GREEN, RED, YELLOW, ENDCOLORS
 
 # The following two imports are only used for the Uptane demonstration, where
@@ -813,7 +817,7 @@ class Primary(object): # Consider inheriting from Secondary and refactoring.
     # that form.
     if tuf.conf.METADATA_FORMAT == 'der':
       converted_attestation = asn1_codec.convert_signed_metadata_to_der(
-          most_recent_attestation, datatype='time_attestation')
+          most_recent_attestation, DATATYPE_TIME_ATTESTATION)
       uptane.formats.DER_DATA_SCHEMA.check_match(converted_attestation)
       return converted_attestation
 
@@ -864,15 +868,15 @@ class Primary(object): # Consider inheriting from Secondary and refactoring.
     if tuf.conf.METADATA_FORMAT == 'der':
       # Convert to DER and sign, replacing the Python dictionary.
       signable_vehicle_manifest = asn1_codec.convert_signed_metadata_to_der(
-          signable_vehicle_manifest, private_key=self.primary_key,
-          resign=True, datatype='vehicle_manifest')
+          signable_vehicle_manifest, DATATYPE_VEHICLE_MANIFEST,
+          private_key=self.primary_key, resign=True)
 
     else:
       # If we're not using ASN.1, sign the Python dictionary in a JSON encoding.
       uptane.common.sign_signable(
           signable_vehicle_manifest,
           [self.primary_key],
-          datatype='vehicle_manifest')
+          DATATYPE_VEHICLE_MANIFEST)
 
       uptane.formats.SIGNABLE_VEHICLE_VERSION_MANIFEST_SCHEMA.check_match(
           signable_vehicle_manifest)
@@ -1025,7 +1029,7 @@ class Primary(object): # Consider inheriting from Secondary and refactoring.
       # If we're working with ASN.1/DER, convert it into the format specified in
       # uptane.formats.SIGNABLE_ECU_VERSION_MANIFEST_SCHEMA.
       signed_ecu_manifest = asn1_codec.convert_signed_der_to_dersigned_json(
-          signed_ecu_manifest, datatype='ecu_manifest')
+          signed_ecu_manifest, DATATYPE_ECU_MANIFEST)
 
     # Else, we're working with standard Python dictionaries and no conversion
     # is necessary, but we'll still validate the signed_ecu_manifest argument.
@@ -1109,7 +1113,7 @@ class Primary(object): # Consider inheriting from Secondary and refactoring.
     # comprehensible instead.
     if tuf.conf.METADATA_FORMAT == 'der':
       timeserver_attestation = asn1_codec.convert_signed_der_to_dersigned_json(
-          timeserver_attestation, datatype='time_attestation')
+          timeserver_attestation, DATATYPE_TIME_ATTESTATION)
 
     # Check format.
     uptane.formats.SIGNABLE_TIMESERVER_ATTESTATION_SCHEMA.check_match(
@@ -1125,7 +1129,7 @@ class Primary(object): # Consider inheriting from Secondary and refactoring.
         self.timeserver_public_key,
         timeserver_attestation['signatures'][0],
         timeserver_attestation['signed'],
-        datatype='time_attestation')
+        DATATYPE_TIME_ATTESTATION)
 
     if not valid:
       raise tuf.BadSignatureError('Timeserver returned an invalid signature. '

--- a/uptane/clients/primary.py
+++ b/uptane/clients/primary.py
@@ -1109,7 +1109,7 @@ class Primary(object): # Consider inheriting from Secondary and refactoring.
     # comprehensible instead.
     if tuf.conf.METADATA_FORMAT == 'der':
       timeserver_attestation = asn1_codec.convert_signed_der_to_dersigned_json(
-          timeserver_attestation)
+          timeserver_attestation, datatype='time_attestation')
 
     # Check format.
     uptane.formats.SIGNABLE_TIMESERVER_ATTESTATION_SCHEMA.check_match(

--- a/uptane/clients/secondary.py
+++ b/uptane/clients/secondary.py
@@ -39,6 +39,9 @@ import uptane.formats
 import uptane.common
 import uptane.encoding.asn1_codec as asn1_codec
 
+from uptane.encoding.asn1_codec import DATATYPE_TIME_ATTESTATION
+from uptane.encoding.asn1_codec import DATATYPE_ECU_MANIFEST
+from uptane.encoding.asn1_codec import DATATYPE_VEHICLE_MANIFEST
 
 from uptane import GREEN, RED, YELLOW, ENDCOLORS
 
@@ -360,8 +363,8 @@ class Secondary(object):
 
     if tuf.conf.METADATA_FORMAT == 'der':
       der_signed_ecu_manifest = asn1_codec.convert_signed_metadata_to_der(
-          signable_ecu_manifest, resign=True,
-          private_key=self.ecu_key, datatype='ecu_manifest')
+          signable_ecu_manifest, DATATYPE_ECU_MANIFEST, resign=True,
+          private_key=self.ecu_key)
       # TODO: Consider verification of output here.
       return der_signed_ecu_manifest
 
@@ -369,7 +372,7 @@ class Secondary(object):
 
     # Now sign with that key.
     uptane.common.sign_signable(
-        signable_ecu_manifest, [self.ecu_key], datatype='ecu_manifest')
+        signable_ecu_manifest, [self.ecu_key], DATATYPE_ECU_MANIFEST)
     uptane.formats.SIGNABLE_ECU_VERSION_MANIFEST_SCHEMA.check_match(
         signable_ecu_manifest)
 
@@ -391,7 +394,7 @@ class Secondary(object):
     # comprehensible (JSON-compatible dictionary) instead.
     if tuf.conf.METADATA_FORMAT == 'der':
       timeserver_attestation = asn1_codec.convert_signed_der_to_dersigned_json(
-          timeserver_attestation, datatype='time_attestation')
+          timeserver_attestation, DATATYPE_TIME_ATTESTATION)
 
     # Check format.
     uptane.formats.SIGNABLE_TIMESERVER_ATTESTATION_SCHEMA.check_match(
@@ -404,7 +407,7 @@ class Secondary(object):
         self.timeserver_public_key,
         timeserver_attestation['signatures'][0],
         timeserver_attestation['signed'],
-        datatype='time_attestation')
+        DATATYPE_TIME_ATTESTATION)
 
     if not valid:
       raise tuf.BadSignatureError('Timeserver returned an invalid signature. '

--- a/uptane/clients/secondary.py
+++ b/uptane/clients/secondary.py
@@ -391,7 +391,7 @@ class Secondary(object):
     # comprehensible (JSON-compatible dictionary) instead.
     if tuf.conf.METADATA_FORMAT == 'der':
       timeserver_attestation = asn1_codec.convert_signed_der_to_dersigned_json(
-          timeserver_attestation)
+          timeserver_attestation, datatype='time_attestation')
 
     # Check format.
     uptane.formats.SIGNABLE_TIMESERVER_ATTESTATION_SCHEMA.check_match(

--- a/uptane/common.py
+++ b/uptane/common.py
@@ -232,7 +232,9 @@ def sign_over_metadata(
     tuf.UnsupportedLibraryError, if an unsupported or unavailable cryptography
     library is chosen.
 
-    uptane.Error, if the given metadata format is not 'json' or 'der'
+    uptane.Error, if the given metadata format is not 'json' or 'der' or if
+    the given datatype is not one of the accepted Uptane data types for
+    conversion (defined in constants asn1_codec.DATATYPE_*)
 
     TypeError, if 'key_dict' contains an invalid keytype.
 

--- a/uptane/common.py
+++ b/uptane/common.py
@@ -130,7 +130,7 @@ def sign_signable(
     # signature to the signatures list in the signable. Add the key used to the
     # list of keys that have already signed and continue to the next key.
     signable['signatures'].append(sign_over_metadata(
-        signing_key, signable['signed'], datatype=datatype,
+        signing_key, signable['signed'], datatype,
         metadata_format=metadata_format))
     keyids_that_already_signed.append(signing_key['keyid'])
 
@@ -261,7 +261,7 @@ def sign_over_metadata(
     # TODO: Have convert_signed_metadata_to_der take just the 'signed' element
     # so we don't have to do this silly wrapping in an empty signable.
     data = asn1_codec.convert_signed_metadata_to_der(
-        {'signed': data, 'signatures': []}, only_signed=True, datatype=datatype)
+        {'signed': data, 'signatures': []}, datatype, only_signed=True)
     data = hashlib.sha256(data).digest()
 
   else: # pragma: no cover
@@ -391,7 +391,7 @@ def verify_signature_over_metadata(
     # TODO: Have convert_signed_metadata_to_der take just the 'signed' element
     # so we don't have to do this silly wrapping in an empty signable.
     data = asn1_codec.convert_signed_metadata_to_der(
-        {'signed': data, 'signatures': []}, only_signed=True, datatype=datatype)
+        {'signed': data, 'signatures': []}, datatype, only_signed=True)
     data = hashlib.sha256(data).digest()
 
   else: # pragma: no cover

--- a/uptane/encoding/asn1_codec.py
+++ b/uptane/encoding/asn1_codec.py
@@ -71,9 +71,8 @@ def ensure_valid_metadata_type_for_asn1(metadata_type):
 
 
 
-# TODO: Remove default datatype and update calling modules to add this
-# parameter.
-def convert_signed_der_to_dersigned_json(der_data, datatype='time_attestation'):
+
+def convert_signed_der_to_dersigned_json(der_data, datatype):
   """
   Convert the given der_data to a Python dictionary representation consistent
   with Uptane's typical JSON encoding.
@@ -218,11 +217,8 @@ def convert_signed_der_to_dersigned_json(der_data, datatype='time_attestation'):
 
 
 
-# TODO: Remove default datatype and update calling modules to add this
-# parameter.
-def convert_signed_metadata_to_der(
-    signed_metadata, private_key=None, resign=False, only_signed=False,
-    datatype='time_attestation'): # TODO: Remove default datatype.
+def convert_signed_metadata_to_der(signed_metadata, datatype,
+    private_key=None, resign=False, only_signed=False):
   """
   Normal behavior ("resign" (re-sign) parameter being False) converts the
   basic Python dictionary format of signed_metadata provided into ASN.1 and

--- a/uptane/encoding/asn1_codec.py
+++ b/uptane/encoding/asn1_codec.py
@@ -27,6 +27,10 @@ import hashlib
 
 logger = logging.getLogger('uptane.asn1_codec')
 
+DATATYPE_TIME_ATTESTATION = 'type__time_attestation'
+DATATYPE_ECU_MANIFEST = 'type__ecu_manifest'
+DATATYPE_VEHICLE_MANIFEST = 'type__vehicle_manifest'
+
 try:
   # pyasn1 modules
   import pyasn1.codec.der.encoder as p_der_encoder
@@ -44,9 +48,9 @@ try:
   # This maps metadata type to the module that lays out the
   # ASN.1 format for that type.
   SUPPORTED_ASN1_METADATA_MODULES = {
-      'time_attestation': timeserver_asn1_coder,
-      'ecu_manifest': ecu_manifest_asn1_coder,
-      'vehicle_manifest': vehicle_manifest_asn1_coder}
+      DATATYPE_TIME_ATTESTATION: timeserver_asn1_coder,
+      DATATYPE_ECU_MANIFEST: ecu_manifest_asn1_coder,
+      DATATYPE_VEHICLE_MANIFEST: vehicle_manifest_asn1_coder}
 
 
 except ImportError:
@@ -149,11 +153,11 @@ def convert_signed_der_to_dersigned_json(der_data, datatype):
   # component of SignedBody()? Anyway, this seems to work.......
   # Handle for the corresponding module.
   relevant_asn_module = SUPPORTED_ASN1_METADATA_MODULES[datatype]
-  if datatype == 'time_attestation':
+  if datatype == DATATYPE_TIME_ATTESTATION:
     exemplar_object = asn1_spec.TokensAndTimestampSignable()
-  elif datatype == 'ecu_manifest':
+  elif datatype == DATATYPE_ECU_MANIFEST:
     exemplar_object = asn1_spec.ECUVersionManifest()#.subtype(implicitTag=p_type_tag.Tag(p_type_tag.tagClassContext, p_type_tag.tagFormatSimple, 3)) # Does this need subtyping?
-  elif datatype == 'vehicle_manifest':
+  elif datatype == DATATYPE_VEHICLE_MANIFEST:
     exemplar_object = asn1_spec.VehicleVersionManifest() # Does this need subtyping?
 
   # exemplar_object = asn1_spec.TokensAndTimestamp().subtype(
@@ -381,11 +385,11 @@ def convert_signed_metadata_to_der(signed_metadata, datatype,
 
   # Now construct an ASN.1 representation of the signed/signatures-encapsulated
   # metadata, populating it.
-  if datatype == 'time_attestation':
+  if datatype == DATATYPE_TIME_ATTESTATION:
     metadata = asn1_spec.TokensAndTimestampSignable()
-  elif datatype == 'ecu_manifest':
+  elif datatype == DATATYPE_ECU_MANIFEST:
     metadata = asn1_spec.ECUVersionManifest()
-  elif datatype == 'vehicle_manifest':
+  elif datatype == DATATYPE_VEHICLE_MANIFEST:
     metadata = asn1_spec.VehicleVersionManifest()
   metadata['signed'] = asn_signed #considering using der_signed instead - requires changes
   metadata['signatures'] = asn_signatures_list # TODO: Support multiple sigs, or integrate with TUF.

--- a/uptane/services/director.py
+++ b/uptane/services/director.py
@@ -44,6 +44,10 @@ from uptane import GREEN, RED, YELLOW, ENDCOLORS
 import os
 import hashlib
 
+from uptane.encoding.asn1_codec import DATATYPE_TIME_ATTESTATION
+from uptane.encoding.asn1_codec import DATATYPE_ECU_MANIFEST
+from uptane.encoding.asn1_codec import DATATYPE_VEHICLE_MANIFEST
+
 log = uptane.logging.getLogger('director')
 log.addHandler(uptane.file_handler)
 log.addHandler(uptane.console_handler)
@@ -191,7 +195,7 @@ class Director:
         ecu_public_key,
         signed_ecu_manifest['signatures'][0], # TODO: Fix single-signature assumption
         signed_ecu_manifest['signed'],
-        datatype='ecu_manifest')
+        DATATYPE_ECU_MANIFEST)
 
     if not valid:
       log.info(
@@ -265,7 +269,7 @@ class Director:
       # Check format and convert back to expected vehicle manifest format.
       uptane.formats.DER_DATA_SCHEMA.check_match(signed_vehicle_manifest)
       signed_vehicle_manifest = asn1_codec.convert_signed_der_to_dersigned_json(
-          signed_vehicle_manifest, datatype='vehicle_manifest')
+          signed_vehicle_manifest, DATATYPE_VEHICLE_MANIFEST)
 
     uptane.formats.SIGNABLE_VEHICLE_VERSION_MANIFEST_SCHEMA.check_match(
         signed_vehicle_manifest)
@@ -389,7 +393,7 @@ class Director:
       # *that* is what is signed, we perform that hashing as well and retrieve
       # the raw binary digest.
       data_to_check = asn1_codec.convert_signed_metadata_to_der(
-          vehicle_manifest, only_signed=True, datatype='vehicle_manifest')
+          vehicle_manifest, DATATYPE_VEHICLE_MANIFEST, only_signed=True)
       data_to_check = hashlib.sha256(data_to_check).digest()
 
     else:
@@ -400,7 +404,7 @@ class Director:
         ecu_public_key,
         vehicle_manifest['signatures'][0], # TODO: Fix assumptions.
         vehicle_manifest['signed'],
-        datatype='vehicle_manifest')
+        DATATYPE_VEHICLE_MANIFEST)
 
     if not valid:
       log.debug(

--- a/uptane/services/timeserver.py
+++ b/uptane/services/timeserver.py
@@ -101,9 +101,8 @@ def get_signed_time_der(nonces):
 
   # Convert it, re-signing over the hash of the DER encoding of the attestation.
   der_attestation = asn1_codec.convert_signed_metadata_to_der(
-      signable_time_attestation,
-      private_key=timeserver_key,
-      resign=True)
+      signable_time_attestation, datatype='time_attestation',
+      private_key=timeserver_key, resign=True)
 
 
   return der_attestation

--- a/uptane/services/timeserver.py
+++ b/uptane/services/timeserver.py
@@ -14,6 +14,9 @@ import uptane # Import before TUF modules; may change tuf.conf values.
 import uptane.formats
 import uptane.common
 import uptane.encoding.asn1_codec as asn1_codec
+
+from uptane.encoding.asn1_codec import DATATYPE_TIME_ATTESTATION
+
 import tuf
 PYASN1_EXISTS = False
 try:
@@ -74,7 +77,7 @@ def get_signed_time(nonces):
   uptane.common.sign_signable(
       signable_time_attestation,
       [timeserver_key],
-      datatype='time_attestation',
+      DATATYPE_TIME_ATTESTATION,
       metadata_format='json')
 
   return signable_time_attestation
@@ -101,7 +104,7 @@ def get_signed_time_der(nonces):
 
   # Convert it, re-signing over the hash of the DER encoding of the attestation.
   der_attestation = asn1_codec.convert_signed_metadata_to_der(
-      signable_time_attestation, datatype='time_attestation',
+      signable_time_attestation, DATATYPE_TIME_ATTESTATION,
       private_key=timeserver_key, resign=True)
 
 


### PR DESCRIPTION
The JSON<->ASN.1/DER conversion functions for Uptane need to be told the datatype of the data they're instructed to convert. (Sidenote: Uptane's TUF fork does not have this problem due to the way the ASN.1 definitions are written.)

Previous to this PR, there was a default datatype if the data type wast not specified: time attestation. This is bad form, and I'm removing it to maintain parity, avoid confusion, and avoid mistakes.

This commit also updates calls made to the function to make sure they include datatype (rather than relying on the default).

While tests succeed locally, I still need to run the demo on this to make sure all is in order.

Edit: I also switched over to using constants to specify data types (ecu manifests, time attestations, vehicle manifests) instead of raw strings.