### PR TITLE
Fix unencountered bug if multiple Primaries in same process

### DIFF
--- a/uptane/clients/primary.py
+++ b/uptane/clients/primary.py
@@ -243,8 +243,7 @@ class Primary(object): # Consider inheriting from Secondary and refactoring.
 
       timeserver_public_key See class docstring above.
 
-      my_secondaries        See class docstring above. (optional: will also be
-                            populated by communication from Secondaries)
+      my_secondaries        See class docstring above. (optional)
 
       time
         An initial time to set the Primary's "clock" to, conforming to

--- a/uptane/clients/primary.py
+++ b/uptane/clients/primary.py
@@ -223,7 +223,7 @@ class Primary(object): # Consider inheriting from Secondary and refactoring.
     primary_key,
     time,
     timeserver_public_key,
-    my_secondaries=[]):
+    my_secondaries=None):
 
     """
     <Purpose>
@@ -243,7 +243,8 @@ class Primary(object): # Consider inheriting from Secondary and refactoring.
 
       timeserver_public_key See class docstring above.
 
-      my_secondaries        See class docstring above. (optional)
+      my_secondaries        See class docstring above. (optional: will also be
+                            populated by communication from Secondaries)
 
       time
         An initial time to set the Primary's "clock" to, conforming to
@@ -282,6 +283,8 @@ class Primary(object): # Consider inheriting from Secondary and refactoring.
     self.timeserver_public_key = timeserver_public_key
     self.primary_key = primary_key
     self.my_secondaries = my_secondaries
+    if self.my_secondaries is None:
+      self.my_secondaries = [] # (because must not use mutable as default value)
     self.director_repo_name = director_repo_name
 
     self.temp_full_metadata_archive_fname = os.path.join(


### PR DESCRIPTION
If multiple Primaries are initialized in the same process and
both are initialized without specifying a list of their
Secondaries, then they will both point to the same list of
Secondaries, updating together, rather than having distinct
lists. This is a Python quirk related to the use of mutables
as default arguments in a function. Mutables should not be
default values because they become common across all calls
made to that function. (It is unlikely that this would have
occurred for anyone, unlikely that any implementer would
inherit this issue in another language, and unlikely to run
multiple Primaries in the same process regardless; however,
it is best to avoid this anti-pattern in Python.)