### PR TITLE
Test Secondary.process_metadata if metadata is missing

### DIFF
--- a/tests/test_secondary.py
+++ b/tests/test_secondary.py
@@ -698,6 +698,12 @@ class TestSecondary(unittest.TestCase):
     self.assertFalse(secondary_instances[2].validated_targets_for_this_ecu)
 
 
+    # Finally, test behavior if the file we indicate does not exist.
+    instance = secondary_instances[0]
+    with self.assertRaises(uptane.Error):
+      instance.process_metadata('some_file_that_does_not_actually_exist.xyz')
+
+
 
 
 


### PR DESCRIPTION
Test behavior of Secondary.process_metadata if it is passed a file that does not exist.

This is a minor additional test and adds a line to code coverage.