### PR TITLE
Fix coverage calculations via tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,6 @@ deps =
     coverage
 
 commands =
-    coverage run --source uptane tests/runtests.py json
-    coverage run --source uptane -a tests/runtests.py der
+    coverage run --include .tox/py*/lib/python*/site-packages/uptane/* tests/runtests.py json
+    coverage run -a --include .tox/py*/lib/python*/site-packages/uptane/* tests/runtests.py der
     coverage report


### PR DESCRIPTION
For unknown reasons (some change in tox or coverage??), coverage
data collection when performed via tox no longer recognized the
correct source files, resulting in apparent 0% coverage. I've
adjusted the tox.ini config so that when tox calls coverage, it
specifies the locations of the source files where they are
installed by tox (that is, .tox/py*/lib/python*/site-packages/uptane/* ).
This leads to corrected coverage calculation when coverage is run via tox.

Coverage calculations when not using tox were unaffected.

Figuring this out was surprisingly tedious....