### PR TITLE
Test: Add more arg testing for asn1_codec.py and common.py

### DIFF
--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -197,6 +197,14 @@ class TestCommon(unittest.TestCase):
         fresh_ecu_manifest['signed'], DATATYPE_ECU_MANIFEST))
 
 
+    # Try providing metadata types that aren't known to sign_over_metadata.
+    with self.assertRaises(uptane.Error):
+      common.sign_over_metadata(keys_pri['primary'],
+          fresh_vehicle_manifest['signed'], 'nonsense_type')
+    with self.assertRaises(uptane.Error):
+      common.sign_over_metadata(keys_pri['primary'],
+          fresh_vehicle_manifest['signed'], 513)
+
 
     # Expect the signatures to come out the same even if a key is specified
     # twice. Try only with ECU Manifests for brevity. (Shouldn't matter)

--- a/uptane/encoding/asn1_codec.py
+++ b/uptane/encoding/asn1_codec.py
@@ -53,7 +53,11 @@ try:
       DATATYPE_VEHICLE_MANIFEST: vehicle_manifest_asn1_coder}
 
 
-except ImportError:
+# This warning is provided in order to be helpful; behavior is not prescribed
+# when a dependency is missing, so this clause is not tested (which would
+# entail tests running after a separate installation with missing
+# dependencies), so this clause is not included in coverage metrics.
+except ImportError: # pragma: no cover
   logger.warning('Minor: pyasn1 library not found. Proceeding using JSON only.')
   PYASN1_EXISTS = False
 
@@ -124,7 +128,13 @@ def convert_signed_der_to_dersigned_json(der_data, datatype):
   """
 
   if not PYASN1_EXISTS:
-    raise uptane.Error('Request was made to load a DER file, but the required '
+    # This error message is provided in order to be helpful; behavior is not
+    # prescribed when a dependency is missing, so this clause is not tested
+    # (which would entail tests running after a separate installation with
+    # missing dependencies), so this clause is not included in coverage
+    # metrics.
+    raise uptane.Error( # pragma: no cover
+        'Request was made to load a DER file, but the required '
         'pyasn1 library failed to import.')
 
   uptane.formats.DER_DATA_SCHEMA.check_match(der_data)


### PR DESCRIPTION
Add more arg testing for asn1_codec.py and common.py
and exclude a couple of lines from coverage metrics since they're
only there to try to be helpful if there is a faulty installation
or if the code changes and impossible things become possible.