### PR TITLE
support setting the clock manually via timeserver attestations

### DIFF
--- a/demo/demo_primary.py
+++ b/demo/demo_primary.py
@@ -254,9 +254,10 @@ def update_cycle():
   # a DER-encoded ASN.1 representation of one.
 
   # This validates the attestation and also saves the time therein (if the
-  # attestation was valid). Secondaries can request this from the Primary at
-  # will.
-  primary_ecu.validate_time_attestation(time_attestation)
+  # attestation was valid), causing this client to use that time for future
+  # metadata expiration checks. Secondaries can request this from the Primary
+  # at will.
+  primary_ecu.update_time(time_attestation)
 
   print('Time attestation validated. New time registered.')
 

--- a/demo/demo_secondary.py
+++ b/demo/demo_secondary.py
@@ -304,10 +304,11 @@ def update_cycle():
   # returns the binary data that we need to write to file.
   metadata_archive = pserver.get_metadata(secondary_ecu.ecu_serial)
 
-  # Validate the time attestation and internalize the time. Continue
-  # regardless.
+  # Verify the time attestation and internalize the time (if verified, the time
+  # will be used in place of system time to perform future metadata expiration
+  # checks).  Continue regardless.
   try:
-    secondary_ecu.validate_time_attestation(time_attestation)
+    secondary_ecu.update_time(time_attestation)
   except uptane.BadTimeAttestation as e:
     print("Timeserver attestation from Primary does not check out: "
         "This Secondary's nonce was not found. Not updating this Secondary's "

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,6 +4,6 @@ cryptography==2.3
 pynacl==1.2.1
 pyasn1==0.4.4
 pycrypto==2.6.1
---editable git://github.com/awwad/tuf.git@develop#egg=tuf
+--editable git://github.com/awwad/tuf.git@support_time_override#egg=tuf
 --editable .
 tox==3.1.2

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,6 +4,6 @@ cryptography==2.3
 pynacl==1.2.1
 pyasn1==0.4.4
 pycrypto==2.6.1
---editable git://github.com/awwad/tuf.git@support_time_override#egg=tuf
+--editable git://github.com/awwad/tuf.git@develop#egg=tuf
 --editable .
 tox==3.1.2

--- a/uptane/clients/primary.py
+++ b/uptane/clients/primary.py
@@ -25,6 +25,7 @@ import shutil # For copyfile
 import random # for nonces
 import zipfile
 import hashlib # if we're using DER encoding
+import iso8601
 
 import tuf.formats
 import tuf.conf
@@ -1160,8 +1161,8 @@ class Primary(object): # Consider inheriting from Secondary and refactoring.
 
     # Make sure the format is understandable to us before saving the
     # attestation and time.  Convert to a UNIX timestamp.
-    new_timeserver_time_unix = int(tuf.formats.unix_timestamp_to_datetime(
-        new_timeserver_time))
+    new_timeserver_time_unix = int(tuf.formats.datetime_to_unix_timestamp(
+        iso8601.parse_date(new_timeserver_time)))
     tuf.formats.UNIX_TIMESTAMP_SCHEMA.check_match(new_timeserver_time_unix)
 
     # Save validated time.

--- a/uptane/clients/primary.py
+++ b/uptane/clients/primary.py
@@ -145,12 +145,12 @@ class Primary(object): # Consider inheriting from Secondary and refactoring.
     #       verification functions.  Do likewise in Secondary.
     self.all_valid_timeserver_attestations:
       A list of all attestations received from Timeservers that have been
-      validated by validate_time_attestation.
+      verified by update_time().
       Items are appended to the end.
 
     self.all_valid_timeserver_times:
       A list of all times extracted from all Timeserver attestations that have
-      been validated by validate_time_attestation.
+      been verified by update_time().
       Items are appended to the end.
 
     self.distributable_full_metadata_archive_fname:
@@ -173,7 +173,7 @@ class Primary(object): # Consider inheriting from Secondary and refactoring.
       generate_signed_vehicle_manifest()
       get_nonces_to_send_and_rotate()
       save_distributable_metadata_files()
-      validate_time_attestation(timeserver_attestation)
+      update_time(timeserver_attestation)
 
     Lower-level methods called by primary_update_cycle() to perform retrieval
     and validation of metadata and data from central services:
@@ -210,7 +210,7 @@ class Primary(object): # Consider inheriting from Secondary and refactoring.
 
     <submit the nonces to the Timeserver and save the returned time attestation>
 
-    p.validate_time_attestation(<the returned time attestation>)
+    p.update_time(<the returned time attestation>)
 
     <metadata> = p.get_metadata_for_ecu(ecu_serial)
     <secondary firmware> = p.get_image_for_ecu(ecu_serial)
@@ -1095,20 +1095,20 @@ class Primary(object): # Consider inheriting from Secondary and refactoring.
 
 
 
-  def validate_time_attestation(self, timeserver_attestation):
+  def update_time(self, timeserver_attestation):
     """
     This should be called after get_nonces_to_send_and_rotate has been called
     and the nonces returned from that have been sent in a request for a time
     attestation from the Timeserver.
 
-    The response from the Timeserver should then be provided to this function
-    to be validated.
-
+    The response from the Timeserver should then be provided to this function.
+    This function attempts to verify the given attestation.
     If timeserver_attestation is correctly signed by the expected Timeserver
     key, and it lists all the nonces we expected it to list (those returned
     by the previous call to get_nonces_to_send_and_rotate), then the Primary's
-    time is updated and the attestation will be saved so that it can be provided
-    to Secondaries.
+    time is updated and the attestation will be saved so that it can be
+    provided to Secondaries.  The new time will be used by this client (via
+    TUF) in in place of system time when checking metadata for expiration.
 
     If the Primary is using ASN.1/DER metadata, then timeserver_attestation is
     expected to be in that format, as a byte string.

--- a/uptane/clients/secondary.py
+++ b/uptane/clients/secondary.py
@@ -29,6 +29,7 @@ import shutil # For copyfile
 import random # for nonces
 import zipfile # to expand the metadata archive retrieved from the Primary
 import hashlib
+import iso8601
 
 import tuf.formats
 import tuf.keys
@@ -442,8 +443,8 @@ class Secondary(object):
 
     # Make sure the format is understandable to us before saving the
     # time.  Convert to a UNIX timestamp.
-    new_timeserver_time_unix = int(tuf.formats.unix_timestamp_to_datetime(
-        new_timeserver_time))
+    new_timeserver_time_unix = int(tuf.formats.datetime_to_unix_timestamp(
+        iso8601.parse_date(new_timeserver_time)))
     tuf.formats.UNIX_TIMESTAMP_SCHEMA.check_match(new_timeserver_time_unix)
 
     # Save validated time.

--- a/uptane/clients/secondary.py
+++ b/uptane/clients/secondary.py
@@ -134,7 +134,7 @@ class Secondary(object):
 
     self.all_valid_timeserver_times:
       A list of all times extracted from all Timeserver attestations that have
-      been validated by validate_time_attestation.
+      been verified by update_time.
       Items are appended to the end.
 
     self.validated_targets_for_this_ecu:
@@ -156,8 +156,8 @@ class Secondary(object):
     Manifest handling:
       generate_signed_ecu_manifest()
 
-    Metadata handling and validation of metadata and data
-      validate_time_attestation(timeserver_attestation)
+    Metadata handling and verification of metadata and data
+      update_time(timeserver_attestation)
       process_metadata(metadata_archive_fname)
       _expand_metadata_archive(metadata_archive_fname)
       fully_validate_metadata()
@@ -298,7 +298,7 @@ class Secondary(object):
 
   def change_nonce(self):
     """
-    This should generally be called only by validate_time_attestation.
+    This should generally be called only by update_time.
 
     To be called only when this Secondary has validated a timeserver
     attestation that lists the current nonce, when we know that nonce has been
@@ -383,13 +383,22 @@ class Secondary(object):
 
 
 
-  def validate_time_attestation(self, timeserver_attestation):
+  def update_time(self, timeserver_attestation):
     """
-    Given a timeserver attestation, validate it (checking that the signature is
-    valid and from the expected key) and ensure that the nonce we expect the
-    attestation to contain is included.
+    The function attemps to verify the time attestation from the Time Server,
+    distributed to us by the Primary.
+    If timeserver_attestation is correctly signed by the expected Timeserver
+    key, and it lists the nonce we expected it to list (the one we last used
+    in a request for the time), then this Secondary's time is updated.
+    The new time will be used by this client (via TUF) in in place of system
+    time when checking metadata for expiration.
 
-    If validation is successful, switch to a new nonce for next time.
+    If the Secondary is using ASN.1/DER metadata, then timeserver_attestation
+    is expected to be in that format, as a byte string.
+    Otherwise, we're using simple Python dictionaries and timeserver_attestation
+    conforms to uptane.formats.SIGNABLE_TIMESERVER_ATTESTATION_SCHEMA.
+
+    If verification is successful, switch to a new nonce for next time.
     """
     # If we're using ASN.1/DER format, convert the attestation into something
     # comprehensible (JSON-compatible dictionary) instead.
@@ -404,13 +413,13 @@ class Secondary(object):
     # Assume there's only one signature.
     assert len(timeserver_attestation['signatures']) == 1
 
-    valid = uptane.common.verify_signature_over_metadata(
+    verified = uptane.common.verify_signature_over_metadata(
         self.timeserver_public_key,
         timeserver_attestation['signatures'][0],
         timeserver_attestation['signed'],
         DATATYPE_TIME_ATTESTATION)
 
-    if not valid:
+    if not verified:
       raise tuf.BadSignatureError('Timeserver returned an invalid signature. '
           'Time is questionable, so not saved. If you see this persistently, '
           'it is possible that there is a Man in the Middle attack underway.')
@@ -421,7 +430,7 @@ class Secondary(object):
     if self.last_nonce_sent is None:
       # This ECU is fresh and hasn't actually ever sent a nonce to the Primary
       # yet. It would be impossible to validate a timeserver attestation.
-      log.warning(YELLOW + 'Cannot validate a timeserver attestation yet: '
+      log.warning(YELLOW + 'Cannot verify a timeserver attestation yet: '
           'this fresh Secondary ECU has never communicated a nonce and ECU '
           'Version Manifest to the Primary.' + ENDCOLORS)
       return
@@ -447,14 +456,14 @@ class Secondary(object):
         iso8601.parse_date(new_timeserver_time)))
     tuf.formats.UNIX_TIMESTAMP_SCHEMA.check_match(new_timeserver_time_unix)
 
-    # Save validated time.
+    # Save verified time.
     self.all_valid_timeserver_times.append(new_timeserver_time)
 
     # Set the client's clock.  This will be used instead of system time by TUF.
     tuf.conf.CLOCK_OVERRIDE = new_timeserver_time_unix
 
     # Use a new nonce next time, since the nonce we were using has now been
-    # used to successfully validate a timeserver attestation.
+    # used to successfully verify a timeserver attestation.
     self.change_nonce()
 
 

--- a/uptane/clients/secondary.py
+++ b/uptane/clients/secondary.py
@@ -440,8 +440,17 @@ class Secondary(object):
     # Extract actual time from the timeserver's signed attestation.
     new_timeserver_time = timeserver_attestation['signed']['time']
 
+    # Make sure the format is understandable to us before saving the
+    # time.  Convert to a UNIX timestamp.
+    new_timeserver_time_unix = int(tuf.formats.unix_timestamp_to_datetime(
+        new_timeserver_time))
+    tuf.formats.UNIX_TIMESTAMP_SCHEMA.check_match(new_timeserver_time_unix)
+
     # Save validated time.
     self.all_valid_timeserver_times.append(new_timeserver_time)
+
+    # Set the client's clock.  This will be used instead of system time by TUF.
+    tuf.conf.CLOCK_OVERRIDE = new_timeserver_time_unix
 
     # Use a new nonce next time, since the nonce we were using has now been
     # used to successfully validate a timeserver attestation.


### PR DESCRIPTION
See #173 for the description of the broader issue.

This PR supports the use of upTUF's manual time override (https://github.com/awwad/tuf/pull/22) to override system time on the Primary and Secondary client when time attestations are verified.

When a time attestation is verified, the clock that TUF and Uptane will use is set to that time, and will remain at that time until updated in the same way.

Tests already employ this functionality, and all added code is covered already, but separate unit (#176) and integration tests (#175) are desirable.  Those issues have been created to cover those needs.