### PR TITLE
Fix repo update order (Director first)

### DIFF
--- a/demo/pinned.json
+++ b/demo/pinned.json
@@ -10,7 +10,7 @@
   "delegations": [
     {
       "paths": ["*"],
-      "repositories": ["imagerepo", "director"]
+      "repositories": ["director", "imagerepo"]
     }
   ]
 }

--- a/demo/pinned_primary_template.json
+++ b/demo/pinned_primary_template.json
@@ -10,7 +10,7 @@
   "delegations": [
     {
       "paths": ["*"],
-      "repositories": ["imagerepo", "director"]
+      "repositories": ["director", "imagerepo"]
     }
   ]
 }

--- a/demo/pinned_secondary_template.json
+++ b/demo/pinned_secondary_template.json
@@ -10,7 +10,7 @@
   "delegations": [
     {
       "paths": ["*"],
-      "repositories": ["imagerepo", "director"]
+      "repositories": ["director", "imagerepo"]
     }
   ]
 }

--- a/tests/test_data/pinned.json
+++ b/tests/test_data/pinned.json
@@ -10,7 +10,7 @@
   "delegations": [
     {
       "paths": ["*"],
-      "repositories": ["imagerepo", "director"]
+      "repositories": ["director", "imagerepo"]
     }
   ]
 }

--- a/tests/test_primary.py
+++ b/tests/test_primary.py
@@ -708,7 +708,7 @@ class TestPrimary(unittest.TestCase):
 
 
 
-  def test_30_refresh_toplevel_metadata_from_repositories(self):
+  def test_30_refresh_toplevel_metadata(self):
 
     # Check that in the fresh temp directory for this test Primary client,
     # there aren't any metadata files except root.json yet.
@@ -720,7 +720,7 @@ class TestPrimary(unittest.TestCase):
         sorted(os.listdir(TEST_IMAGE_REPO_METADATA_DIR)))
 
     try:
-      TestPrimary.instance.refresh_toplevel_metadata_from_repositories()
+      TestPrimary.instance.refresh_toplevel_metadata()
     except (URLError, tuf.NoWorkingMirrorError) as e:
       pass
     else:


### PR DESCRIPTION
For both Uptane Standard conformance ([Uptane Standard 5.4.4.2](https://uptane.github.io/uptane-standard/uptane-standard.html#full_verification)) and the resolution to the
Timeserver fast-forward attack (discussed in #173), it is important for clients to
update Director Repository metadata before Image Repository metadata.

This PR:
- primarily, makes sure that the Director repo is updated first by modifying the update procedure in `secondary.py` and `primary.py`.
- incidentally, also updates the demo and testing mapping metadata (`pinned.json`) in order to avoid any suggestion that the Director repository is updated after the Image Repository
- incidentally, it also makes the `primary.py` and `secondary.py` top-level metadata refresh
procedure identical, for future modularization.  This includes a rename in primary.py of refresh_toplevel_metadata_from_repositories to just refresh_toplevel_metadata, which is the same name the function has in secondary.py.  While both names are accurate in a sense, the former could be misleading in secondary.py.
- updates testing accordingly