### PR TITLE
Fix failing Python 3.4 Travis builds + general ci/cd enhancements

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,9 @@
+[run]
+branch = True
+
+omit =
+  */site-package/*
+  */python?.?/*
+  */tuf/*
+  tests/*
+  demo/*

--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,12 @@ v2/*
 temp_*
 __pycache__/*
 tuf.log
+uptane.log
 clean_*/*
 temp_*/*
 *.egg-info
 __pycache__
 *.pyc
+.tox/
+htmlcov/
+.coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
 language:
     python
 
-python:
-    - "2.7"
-
-#env:
-#    TOXENV=py27
+matrix:
+    include:
+        - python: "2.7"
+          env: TOXENV=py27
+        - python: "3.4"
+          env: TOXENV=py34
+        - python: "3.5"
+          env: TOXENV=py35
 
 install:
     - pip install tox coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@
 # and in the second, they will be run in ASN.1/DER mode.
 
 [tox]
-envlist = py{27,34}
+envlist = py{27,34,35}
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@
 
 [tox]
 envlist = py{27,34,35}
+skipsdist = True
 
 [testenv]
 deps =
@@ -16,6 +17,6 @@ deps =
     coverage
 
 commands =
-    coverage run --include .tox/py*/lib/python*/site-packages/uptane/* tests/runtests.py json
-    coverage run -a --include .tox/py*/lib/python*/site-packages/uptane/* tests/runtests.py der
+    coverage run tests/runtests.py json
+    coverage run -a tests/runtests.py der
     coverage report


### PR DESCRIPTION
### Purpose of the PR:
- Fixes failing Python 3.4 Travis builds
- Enables Python 3.5 testing with tox and Travis
- Enables build matrix for parallel builds and to publish one coverage report per build on coveralls.io
- Generally enhances coverage reporting (adds branch coverage, uses relative paths) 

### Summary of Changes:

Please see very detailed commit messages for background information.

### Further Requirements:
(If documentation or the demo needs to be changed due to this PR, has this
already been included in the PR? What still needs to be done?)
