### PR TITLE
Remove pycrypto

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,7 +3,6 @@ cffi==1.11.5
 cryptography==2.3
 pynacl==1.2.1
 pyasn1==0.4.4
-pycrypto==2.6.1
 --editable git://github.com/awwad/tuf.git@develop#egg=tuf
 --editable .
 tox==3.1.2


### PR DESCRIPTION
### Purpose of the PR:

Remove pycrypto.

### Summary of Changes:

I don't think we need the vulnerable `pycrypto` when we have `cryptography`. Can someone confirm?

### Further Requirements:

Needs testing to see if this can be safely removed.